### PR TITLE
Clean up

### DIFF
--- a/src/main/java/javax/servlet/GenericFilter.java
+++ b/src/main/java/javax/servlet/GenericFilter.java
@@ -16,7 +16,6 @@
 
 package javax.servlet;
 
-import java.io.IOException;
 import java.util.Enumeration;
 import java.util.ResourceBundle;
 

--- a/src/main/java/javax/servlet/GenericFilter.java
+++ b/src/main/java/javax/servlet/GenericFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/GenericFilter.java
+++ b/src/main/java/javax/servlet/GenericFilter.java
@@ -47,6 +47,8 @@ import java.util.ResourceBundle;
 public abstract class GenericFilter 
     implements Filter, FilterConfig, java.io.Serializable
 {
+    private static final long serialVersionUID = 4060116231031076581L;
+
     private static final String LSTRING_FILE = "javax.servlet.LocalStrings";
     private static final ResourceBundle lStrings =
         ResourceBundle.getBundle(LSTRING_FILE);

--- a/src/main/java/javax/servlet/GenericServlet.java
+++ b/src/main/java/javax/servlet/GenericServlet.java
@@ -50,6 +50,8 @@ import java.util.ResourceBundle;
 public abstract class GenericServlet 
     implements Servlet, ServletConfig, java.io.Serializable
 {
+    private static final long serialVersionUID = -8592279577370996712L;
+
     private static final String LSTRING_FILE = "javax.servlet.LocalStrings";
     private static ResourceBundle lStrings =
         ResourceBundle.getBundle(LSTRING_FILE);

--- a/src/main/java/javax/servlet/GenericServlet.java
+++ b/src/main/java/javax/servlet/GenericServlet.java
@@ -72,6 +72,7 @@ public abstract class GenericServlet
      *
      * 
      */
+    @Override
     public void destroy() {
     }
     
@@ -92,6 +93,7 @@ public abstract class GenericServlet
      *				of the initialization parameter
      *
      */ 
+    @Override
     public String getInitParameter(String name) {
         ServletConfig sc = getServletConfig();
         if (sc == null) {
@@ -118,6 +120,7 @@ public abstract class GenericServlet
     *				objects containing the names of 
     *				the servlet's initialization parameters
     */
+    @Override
     public Enumeration<String> getInitParameterNames() {
         ServletConfig sc = getServletConfig();
         if (sc == null) {
@@ -135,6 +138,7 @@ public abstract class GenericServlet
      * @return ServletConfig 	the <code>ServletConfig</code> object
      *				that initialized this servlet
      */    
+    @Override
     public ServletConfig getServletConfig() {
 	return config;
     }
@@ -152,6 +156,7 @@ public abstract class GenericServlet
      *				passed to this servlet by the <code>init</code>
      *				method
      */
+    @Override
     public ServletContext getServletContext() {
         ServletConfig sc = getServletConfig();
         if (sc == null) {
@@ -174,6 +179,7 @@ public abstract class GenericServlet
      * @return String 		information about this servlet, by default an
      * 				empty string
      */    
+    @Override
     public String getServletInfo() {
 	return "";
     }
@@ -198,6 +204,7 @@ public abstract class GenericServlet
      * 
      * @see 				UnavailableException
      */
+    @Override
     public void init(ServletConfig config) throws ServletException {
 	this.config = config;
 	this.init();
@@ -274,6 +281,7 @@ public abstract class GenericServlet
      *					exception occurs
      */
 
+    @Override
     public abstract void service(ServletRequest req, ServletResponse res)
 	throws ServletException, IOException;
     
@@ -284,6 +292,7 @@ public abstract class GenericServlet
      *
      * @return          the name of this servlet instance
      */
+    @Override
     public String getServletName() {
         ServletConfig sc = getServletConfig();
         if (sc == null) {

--- a/src/main/java/javax/servlet/GenericServlet.java
+++ b/src/main/java/javax/servlet/GenericServlet.java
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
- * Copyright 2004 The Apache Software Foundation
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation  
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/javax/servlet/HttpConstraintElement.java
+++ b/src/main/java/javax/servlet/HttpConstraintElement.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/HttpConstraintElement.java
+++ b/src/main/java/javax/servlet/HttpConstraintElement.java
@@ -16,7 +16,6 @@
 
 package javax.servlet;
 
-import java.util.*;
 import javax.servlet.annotation.HttpConstraint;
 import javax.servlet.annotation.ServletSecurity.EmptyRoleSemantic;
 import javax.servlet.annotation.ServletSecurity.TransportGuarantee;

--- a/src/main/java/javax/servlet/ServletContext.java
+++ b/src/main/java/javax/servlet/ServletContext.java
@@ -954,6 +954,8 @@ public interface ServletContext {
      * Gets the ServletRegistration corresponding to the servlet with the
      * given <tt>servletName</tt>.
      *
+     * @param servletName the name of a servlet
+     *
      * @return the (complete or preliminary) ServletRegistration for the
      * servlet with the given <tt>servletName</tt>, or null if no
      * ServletRegistration exists under that name
@@ -964,7 +966,6 @@ public interface ServletContext {
      * <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated
      * with {@link javax.servlet.annotation.WebListener}
      *
-     * @param servletName the name of a servlet
      * @since Servlet 3.0
      */
     public ServletRegistration getServletRegistration(String servletName);

--- a/src/main/java/javax/servlet/ServletContext.java
+++ b/src/main/java/javax/servlet/ServletContext.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletContext.java
+++ b/src/main/java/javax/servlet/ServletContext.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Enumeration;
-import java.util.EnumSet;
 import java.util.EventListener;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/javax/servlet/ServletContextAttributeListener.java
+++ b/src/main/java/javax/servlet/ServletContextAttributeListener.java
@@ -65,7 +65,7 @@ public interface ServletContextAttributeListener extends EventListener {
      */
     default public void attributeRemoved(ServletContextAttributeEvent event) {}
 
-    /*
+    /**
      * Receives notification that an attribute has been replaced
      * in the ServletContext.
      *

--- a/src/main/java/javax/servlet/ServletContextAttributeListener.java
+++ b/src/main/java/javax/servlet/ServletContextAttributeListener.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletException.java
+++ b/src/main/java/javax/servlet/ServletException.java
@@ -28,6 +28,8 @@ package javax.servlet;
 
 public class ServletException extends Exception {
 
+    private static final long serialVersionUID = 4221302886851315160L;
+
     private Throwable rootCause;
 
 

--- a/src/main/java/javax/servlet/ServletException.java
+++ b/src/main/java/javax/servlet/ServletException.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletRequest.java
+++ b/src/main/java/javax/servlet/ServletRequest.java
@@ -427,6 +427,7 @@ public interface ServletRequest {
      * @deprecated  As of Version 2.1 of the Java Servlet API,
      *    use {@link ServletContext#getRealPath} instead.
      */
+    @Deprecated
     public String getRealPath(String path);
     
     /**

--- a/src/main/java/javax/servlet/ServletRequest.java
+++ b/src/main/java/javax/servlet/ServletRequest.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletRequestWrapper.java
+++ b/src/main/java/javax/servlet/ServletRequestWrapper.java
@@ -84,6 +84,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to call getAttribute(String name)
      * on the wrapped request object.
      */
+    @Override
     public Object getAttribute(String name) {
         return this.request.getAttribute(name);
     }
@@ -93,6 +94,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getAttributeNames()
      * on the wrapped request object.
      */
+    @Override
     public Enumeration<String> getAttributeNames() {
         return this.request.getAttributeNames();
     }    
@@ -102,6 +104,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getCharacterEncoding()
      * on the wrapped request object.
      */
+    @Override
     public String getCharacterEncoding() {
         return this.request.getCharacterEncoding();
     }
@@ -111,6 +114,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to set the character encoding
      * on the wrapped request object.
      */
+    @Override
     public void setCharacterEncoding(String enc)
             throws UnsupportedEncodingException {
         this.request.setCharacterEncoding(enc);
@@ -121,6 +125,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getContentLength()
      * on the wrapped request object.
      */
+    @Override
     public int getContentLength() {
         return this.request.getContentLength();
     }
@@ -131,6 +136,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.1
      */
+    @Override
     public long getContentLengthLong() {
         return this.request.getContentLengthLong();
     }
@@ -140,6 +146,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getContentType()
      * on the wrapped request object.
      */
+    @Override
     public String getContentType() {
         return this.request.getContentType();
     }
@@ -149,6 +156,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getInputStream()
      * on the wrapped request object.
      */
+    @Override
     public ServletInputStream getInputStream() throws IOException {
         return this.request.getInputStream();
     }
@@ -158,6 +166,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return
      * getParameter(String name) on the wrapped request object.
      */
+    @Override
     public String getParameter(String name) {
         return this.request.getParameter(name);
     }
@@ -167,6 +176,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getParameterMap()
      * on the wrapped request object.
      */
+    @Override
     public Map<String, String[]> getParameterMap() {
         return this.request.getParameterMap();
     }
@@ -176,6 +186,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getParameterNames()
      * on the wrapped request object.
      */
+    @Override
     public Enumeration<String> getParameterNames() {
         return this.request.getParameterNames();
     }
@@ -185,6 +196,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return
      * getParameterValues(String name) on the wrapped request object.
      */
+    @Override
     public String[] getParameterValues(String name) {
         return this.request.getParameterValues(name);
     }
@@ -194,6 +206,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getProtocol()
      * on the wrapped request object.
      */
+    @Override
     public String getProtocol() {
         return this.request.getProtocol();
     }
@@ -203,6 +216,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getScheme()
      * on the wrapped request object.
      */
+    @Override
     public String getScheme() {
         return this.request.getScheme();
     }
@@ -212,6 +226,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getServerName()
      * on the wrapped request object.
      */
+    @Override
     public String getServerName() {
         return this.request.getServerName();
     }
@@ -221,6 +236,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getServerPort()
      * on the wrapped request object.
      */
+    @Override
     public int getServerPort() {
         return this.request.getServerPort();
     }
@@ -230,6 +246,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getReader()
      * on the wrapped request object.
      */
+    @Override
     public BufferedReader getReader() throws IOException {
         return this.request.getReader();
     }
@@ -239,6 +256,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getRemoteAddr()
      * on the wrapped request object.
      */
+    @Override
     public String getRemoteAddr() {
         return this.request.getRemoteAddr();
     }
@@ -248,6 +266,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getRemoteHost()
      * on the wrapped request object.
      */
+    @Override
     public String getRemoteHost() {
         return this.request.getRemoteHost();
     }
@@ -257,6 +276,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return
      * setAttribute(String name, Object o) on the wrapped request object.
      */
+    @Override
     public void setAttribute(String name, Object o) {
         this.request.setAttribute(name, o);
     }
@@ -266,6 +286,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to call
      * removeAttribute(String name) on the wrapped request object.
      */
+    @Override
     public void removeAttribute(String name) {
         this.request.removeAttribute(name);
     }
@@ -275,6 +296,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getLocale()
      * on the wrapped request object.
      */
+    @Override
     public Locale getLocale() {
         return this.request.getLocale();
     }
@@ -284,6 +306,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return getLocales()
      * on the wrapped request object.
      */
+    @Override
     public Enumeration<Locale> getLocales() {
         return this.request.getLocales();
     }
@@ -293,6 +316,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return isSecure()
      * on the wrapped request object.
      */
+    @Override
     public boolean isSecure() {
         return this.request.isSecure();
     }
@@ -302,6 +326,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * The default behavior of this method is to return
      * getRequestDispatcher(String path) on the wrapped request object.
      */
+    @Override
     public RequestDispatcher getRequestDispatcher(String path) {
         return this.request.getRequestDispatcher(path);
     }
@@ -314,6 +339,7 @@ public class ServletRequestWrapper implements ServletRequest {
      * @deprecated As of Version 2.1 of the Java Servlet API,
      * use {@link ServletContext#getRealPath} instead
      */
+    @Override
     @Deprecated
     public String getRealPath(String path) {
         return this.request.getRealPath(path);
@@ -326,6 +352,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 2.4
      */    
+    @Override
     public int getRemotePort(){
         return this.request.getRemotePort();
     }
@@ -337,6 +364,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 2.4
      */
+    @Override
     public String getLocalName(){
         return this.request.getLocalName();
     }
@@ -348,6 +376,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 2.4
      */       
+    @Override
     public String getLocalAddr(){
         return this.request.getLocalAddr();
     }
@@ -359,6 +388,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 2.4
      */
+    @Override
     public int getLocalPort(){
         return this.request.getLocalPort();
     }
@@ -373,6 +403,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public ServletContext getServletContext() {
         return request.getServletContext();
     }
@@ -397,6 +428,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public AsyncContext startAsync() throws IllegalStateException {
         return request.startAsync();
     }
@@ -427,6 +459,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public AsyncContext startAsync(ServletRequest servletRequest,
                                    ServletResponse servletResponse)
             throws IllegalStateException {
@@ -444,6 +477,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public boolean isAsyncStarted() {
         return request.isAsyncStarted();
     }
@@ -459,6 +493,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public boolean isAsyncSupported() {
         return request.isAsyncSupported();
     }
@@ -483,6 +518,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public AsyncContext getAsyncContext() {
         return request.getAsyncContext();
     }
@@ -550,6 +586,7 @@ public class ServletRequestWrapper implements ServletRequest {
      *
      * @since Servlet 3.0
      */
+    @Override
     public DispatcherType getDispatcherType() {
         return request.getDispatcherType();
     }

--- a/src/main/java/javax/servlet/ServletRequestWrapper.java
+++ b/src/main/java/javax/servlet/ServletRequestWrapper.java
@@ -41,9 +41,10 @@ public class ServletRequestWrapper implements ServletRequest {
 
     /**
      * Creates a ServletRequest adaptor wrapping the given request object. 
-     * @throws java.lang.IllegalArgumentException if the request is null
      *
      * @param request the {@link ServletRequest} to be wrapped
+     *
+     * @throws java.lang.IllegalArgumentException if the request is null
      */
     public ServletRequestWrapper(ServletRequest request) {
         if (request == null) {

--- a/src/main/java/javax/servlet/ServletRequestWrapper.java
+++ b/src/main/java/javax/servlet/ServletRequestWrapper.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletResponse.java
+++ b/src/main/java/javax/servlet/ServletResponse.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletResponse.java
+++ b/src/main/java/javax/servlet/ServletResponse.java
@@ -75,7 +75,7 @@ public interface ServletResponse {
      * that container, using vendor specific configuration).
      * The first one of these methods that yields a result is returned.
      * Per-request, the charset for the response can be specified explicitly
-     * using the {@link setCharacterEncoding} and {@link setContentType}
+     * using the {@link #setCharacterEncoding} and {@link #setContentType}
      * methods, or implicitly using the setLocale(java.util.Locale) method.
      * Explicit specifications take precedence over implicit specifications.
      * Calls made to these methods after <code>getWriter</code> has been

--- a/src/main/java/javax/servlet/ServletResponseWrapper.java
+++ b/src/main/java/javax/servlet/ServletResponseWrapper.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/ServletResponseWrapper.java
+++ b/src/main/java/javax/servlet/ServletResponseWrapper.java
@@ -83,6 +83,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * @since Servlet 2.4
      */
 
+    @Override
     public void setCharacterEncoding(String charset) {
 	this.response.setCharacterEncoding(charset);
     }
@@ -92,6 +93,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public String getCharacterEncoding() {
 	return this.response.getCharacterEncoding();
 	}
@@ -102,6 +104,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public ServletOutputStream getOutputStream() throws IOException {
 	return this.response.getOutputStream();
     }  
@@ -112,6 +115,7 @@ public class ServletResponseWrapper implements ServletResponse {
      */
 
 
+    @Override
     public PrintWriter getWriter() throws IOException {
 	return this.response.getWriter();
 	}
@@ -121,6 +125,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public void setContentLength(int len) {
 	this.response.setContentLength(len);
     }
@@ -130,6 +135,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public void setContentLengthLong(long len) {
         this.response.setContentLengthLong(len);
     }
@@ -139,6 +145,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public void setContentType(String type) {
 	this.response.setContentType(type);
     }
@@ -150,6 +157,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * @since Servlet 2.4
      */
 
+    @Override
     public String getContentType() {
 	return this.response.getContentType();
     }
@@ -158,6 +166,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * The default behavior of this method is to call setBufferSize(int size)
      * on the wrapped response object.
      */
+    @Override
     public void setBufferSize(int size) {
 	this.response.setBufferSize(size);
     }
@@ -166,6 +175,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * The default behavior of this method is to return getBufferSize()
      * on the wrapped response object.
      */
+    @Override
     public int getBufferSize() {
 	return this.response.getBufferSize();
     }
@@ -175,6 +185,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public void flushBuffer() throws IOException {
 	this.response.flushBuffer();
     }
@@ -183,6 +194,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * The default behavior of this method is to return isCommitted()
      * on the wrapped response object.
      */
+    @Override
     public boolean isCommitted() {
 	return this.response.isCommitted();
     }
@@ -192,6 +204,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public void reset() {
 	this.response.reset();
     }
@@ -201,6 +214,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
      
+    @Override
     public void resetBuffer() {
 	this.response.resetBuffer();
     }
@@ -210,6 +224,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * on the wrapped response object.
      */
 
+    @Override
     public void setLocale(Locale loc) {
 	this.response.setLocale(loc);
     }
@@ -218,6 +233,7 @@ public class ServletResponseWrapper implements ServletResponse {
      * The default behavior of this method is to return getLocale()
      * on the wrapped response object.
      */
+    @Override
     public Locale getLocale() {
 	return this.response.getLocale();
     }

--- a/src/main/java/javax/servlet/ServletResponseWrapper.java
+++ b/src/main/java/javax/servlet/ServletResponseWrapper.java
@@ -37,20 +37,20 @@ import java.util.Locale;
  
 public class ServletResponseWrapper implements ServletResponse {
 	private ServletResponse response;
-	/**
-	* Creates a ServletResponse adaptor wrapping the given response object.
-	* @throws java.lang.IllegalArgumentException if the response is null.
-        * @param response the {@link ServletResponse} to be wrapped
-        *
-	*/
 
-
-	public ServletResponseWrapper(ServletResponse response) {
-	    if (response == null) {
-		throw new IllegalArgumentException("Response cannot be null");
-	    }
-	    this.response = response;
-	}
+    /**
+     * Creates a ServletResponse adaptor wrapping the given response object.
+     *
+     * @param response the {@link ServletResponse} to be wrapped
+     *
+     * @throws java.lang.IllegalArgumentException if the response is null.
+     */
+    public ServletResponseWrapper(ServletResponse response) {
+        if (response == null) {
+            throw new IllegalArgumentException("Response cannot be null");
+        }
+        this.response = response;
+    }
 
 	/**
 	* Return the wrapped ServletResponse object.
@@ -62,20 +62,19 @@ public class ServletResponseWrapper implements ServletResponse {
 		return this.response;
 	}	
 	
-	
-	/**
-	* Sets the response being wrapped. 
-	* @throws java.lang.IllegalArgumentException if the response is null.
-        *
-        * @param response the {@link ServletResponse} to be installed 
-	*/
-	
-	public void setResponse(ServletResponse response) {
-	    if (response == null) {
-		throw new IllegalArgumentException("Response cannot be null");
-	    }
-	    this.response = response;
-	}
+    /**
+     * Sets the response being wrapped.
+     *
+     * @param response the {@link ServletResponse} to be installed
+     *
+     * @throws java.lang.IllegalArgumentException if the response is null.
+     */
+    public void setResponse(ServletResponse response) {
+        if (response == null) {
+            throw new IllegalArgumentException("Response cannot be null");
+        }
+        this.response = response;
+    }
 
     /**
      * The default behavior of this method is to call setCharacterEncoding(String charset)

--- a/src/main/java/javax/servlet/ServletSecurityElement.java
+++ b/src/main/java/javax/servlet/ServletSecurityElement.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/ServletSecurityElement.java
+++ b/src/main/java/javax/servlet/ServletSecurityElement.java
@@ -36,7 +36,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
      * element and with no HTTP Method specific constraint elements.
      */
     public ServletSecurityElement() {
-        methodConstraints = new HashSet<HttpMethodConstraintElement>();
+        methodConstraints = new HashSet<>();
         methodNames = Collections.emptySet();
     }
 
@@ -52,7 +52,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
         super(constraint.getEmptyRoleSemantic(),
                 constraint.getTransportGuarantee(),
                 constraint.getRolesAllowed());
-        methodConstraints = new HashSet<HttpMethodConstraintElement>();
+        methodConstraints = new HashSet<>();
         methodNames = Collections.emptySet();
     }
 
@@ -71,7 +71,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
     public ServletSecurityElement(
             Collection<HttpMethodConstraintElement> methodConstraints) {
         this.methodConstraints = (methodConstraints == null ?
-            new HashSet<HttpMethodConstraintElement>() : methodConstraints);
+            new HashSet<>() : methodConstraints);
         methodNames = checkMethodNames(this.methodConstraints);
     }
 
@@ -94,7 +94,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
                 constraint.getTransportGuarantee(),
                 constraint.getRolesAllowed());
         this.methodConstraints = (methodConstraints == null ?
-            new HashSet<HttpMethodConstraintElement>() : methodConstraints);
+            new HashSet<>() : methodConstraints);
         methodNames = checkMethodNames(this.methodConstraints);
     }
 
@@ -110,7 +110,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
         super(annotation.value().value(),
                 annotation.value().transportGuarantee(),
                 annotation.value().rolesAllowed());
-        this.methodConstraints = new HashSet<HttpMethodConstraintElement>();
+        this.methodConstraints = new HashSet<>();
         for (HttpMethodConstraint constraint :
                 annotation.httpMethodConstraints()) {
             this.methodConstraints.add(
@@ -164,7 +164,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
      */
     private Collection<String> checkMethodNames(
             Collection<HttpMethodConstraintElement> methodConstraints) {
-        Collection<String> methodNames = new HashSet<String>();
+        Collection<String> methodNames = new HashSet<>();
         for (HttpMethodConstraintElement methodConstraint :
                         methodConstraints) {
             String methodName = methodConstraint.getMethodName();

--- a/src/main/java/javax/servlet/UnavailableException.java
+++ b/src/main/java/javax/servlet/UnavailableException.java
@@ -50,6 +50,8 @@ package javax.servlet;
 public class UnavailableException
 extends ServletException {
 
+    private static final long serialVersionUID = 5622686609215003468L;
+
     private Servlet     servlet;           // what's unavailable
     private boolean     permanent;         // needs admin action?
     private int         seconds;           // unavailability estimate

--- a/src/main/java/javax/servlet/UnavailableException.java
+++ b/src/main/java/javax/servlet/UnavailableException.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/annotation/WebFilter.java
+++ b/src/main/java/javax/servlet/annotation/WebFilter.java
@@ -115,8 +115,8 @@ public @interface WebFilter {
      *
      * @return {@code true} if the filter supports asynchronous operation mode
      * @see javax.servlet.ServletRequest#startAsync
-     * @see javax.servlet.ServletRequest#startAsync(ServletRequest,
-     * ServletResponse)
+     * @see javax.servlet.ServletRequest#startAsync(
+     * javax.servlet.ServletRequest,javax.servlet.ServletResponse)
      */
     boolean asyncSupported() default false;
 

--- a/src/main/java/javax/servlet/annotation/WebFilter.java
+++ b/src/main/java/javax/servlet/annotation/WebFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/annotation/WebServlet.java
+++ b/src/main/java/javax/servlet/annotation/WebServlet.java
@@ -78,8 +78,8 @@ public @interface WebServlet {
      *
      * @return {@code true} if the servlet supports asynchronous operation mode
      * @see javax.servlet.ServletRequest#startAsync
-     * @see javax.servlet.ServletRequest#startAsync(ServletRequest,
-     * ServletResponse)
+     * @see javax.servlet.ServletRequest#startAsync(
+     * javax.servlet.ServletRequest,javax.servlet.ServletResponse)
      */
     boolean asyncSupported() default false;
     

--- a/src/main/java/javax/servlet/annotation/WebServlet.java
+++ b/src/main/java/javax/servlet/annotation/WebServlet.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/http/Cookie.java
+++ b/src/main/java/javax/servlet/http/Cookie.java
@@ -422,6 +422,7 @@ public class Cookie implements Cloneable, Serializable {
      * Overrides the standard <code>java.lang.Object.clone</code> 
      * method to return a copy of this Cookie.
      */
+    @Override
     public Object clone() {
         try {
             return super.clone();

--- a/src/main/java/javax/servlet/http/Cookie.java
+++ b/src/main/java/javax/servlet/http/Cookie.java
@@ -71,7 +71,7 @@ public class Cookie implements Cloneable, Serializable {
         ResourceBundle.getBundle(LSTRING_FILE);
 
     static {
-        if (Boolean.valueOf(System.getProperty("org.glassfish.web.rfc2109_cookie_names_enforced", "true"))) {
+        if (Boolean.valueOf(System.getProperty("org.glassfish.web.rfc2109_cookie_names_enforced", "true")).booleanValue()) {
             TSPECIALS = "/()<>@,;:\\\"[]?={} \t";
         } else {
             TSPECIALS = ",; ";

--- a/src/main/java/javax/servlet/http/Cookie.java
+++ b/src/main/java/javax/servlet/http/Cookie.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/http/HttpFilter.java
+++ b/src/main/java/javax/servlet/http/HttpFilter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/http/HttpFilter.java
+++ b/src/main/java/javax/servlet/http/HttpFilter.java
@@ -50,6 +50,8 @@ import javax.servlet.ServletResponse;
 public abstract class HttpFilter extends GenericFilter
 {
     
+    private static final long serialVersionUID = 7478463438252262094L;
+
     /**
      * <p>Does nothing, because this is an abstract class.</p>
      * 

--- a/src/main/java/javax/servlet/http/HttpServlet.java
+++ b/src/main/java/javax/servlet/http/HttpServlet.java
@@ -907,10 +907,12 @@ class NoBodyOutputStream extends ServletOutputStream {
     }
 
 
+    @Override
     public boolean isReady() {
         return false;
     }
 
+    @Override
     public void setWriteListener(WriteListener writeListener) {
 
     }

--- a/src/main/java/javax/servlet/http/HttpServlet.java
+++ b/src/main/java/javax/servlet/http/HttpServlet.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/http/HttpServlet.java
+++ b/src/main/java/javax/servlet/http/HttpServlet.java
@@ -73,6 +73,8 @@ import javax.servlet.*;
 
 public abstract class HttpServlet extends GenericServlet
 {
+    private static final long serialVersionUID = 8466325577512134784L;
+
     private static final String METHOD_DELETE = "DELETE";
     private static final String METHOD_HEAD = "HEAD";
     private static final String METHOD_GET = "GET";

--- a/src/main/java/javax/servlet/http/HttpServletMapping.java
+++ b/src/main/java/javax/servlet/http/HttpServletMapping.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/src/main/java/javax/servlet/http/HttpServletMapping.java
+++ b/src/main/java/javax/servlet/http/HttpServletMapping.java
@@ -93,12 +93,12 @@ public interface HttpServletMapping {
     
     /**
      * <p>Return the portion of the URI path that caused this request to
-     * be matched.  If the {@link getMappingMatch} value is {@code
+     * be matched.  If the {@link #getMappingMatch} value is {@code
      * CONTEXT_ROOT} or {@code DEFAULT}, this method must return the
-     * empty string.  If the {@link getMappingMatch} value is {@code
+     * empty string.  If the {@link #getMappingMatch} value is {@code
      * EXACT}, this method must return the portion of the path that
      * matched the servlet, omitting any leading slash.  If the {@link
-     * getMappingMatch} value is {@code EXTENSION} or {@code PATH}, this
+     * #getMappingMatch} value is {@code EXTENSION} or {@code PATH}, this
      * method must return the value that matched the '*'.  See the class
      * javadoc for examples. </p>
      * 
@@ -110,9 +110,9 @@ public interface HttpServletMapping {
 
     /**
      * <p>Return the String representation for the {@code url-pattern}
-     * for this mapping.  If the {@link getMappingMatch} value is {@code
+     * for this mapping.  If the {@link #getMappingMatch} value is {@code
      * CONTEXT_ROOT} or {@code DEFAULT}, this method must return the
-     * empty string. If the {@link getMappingMatch} value is {@code
+     * empty string. If the {@link #getMappingMatch} value is {@code
      * EXTENSION}, this method must return the pattern, without any
      * leading slash.  Otherwise, this method returns the pattern
      * exactly as specified in the descriptor or Java configuration.</p>

--- a/src/main/java/javax/servlet/http/HttpServletRequestWrapper.java
+++ b/src/main/java/javax/servlet/http/HttpServletRequestWrapper.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/http/HttpServletRequestWrapper.java
+++ b/src/main/java/javax/servlet/http/HttpServletRequestWrapper.java
@@ -39,9 +39,10 @@ public class HttpServletRequestWrapper extends ServletRequestWrapper implements 
 
     /** 
      * Constructs a request object wrapping the given request.
-     * @throws java.lang.IllegalArgumentException if the request is null
-     
+     *
      * @param request the {@link HttpServletRequest} to be wrapped.
+     *
+     * @throws java.lang.IllegalArgumentException if the request is null
      */
     public HttpServletRequestWrapper(HttpServletRequest request) {
         super(request);

--- a/src/main/java/javax/servlet/http/HttpServletResponseWrapper.java
+++ b/src/main/java/javax/servlet/http/HttpServletResponseWrapper.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/http/HttpServletResponseWrapper.java
+++ b/src/main/java/javax/servlet/http/HttpServletResponseWrapper.java
@@ -40,9 +40,10 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
 
     /** 
      * Constructs a response adaptor wrapping the given response.
-     * @throws java.lang.IllegalArgumentException if the response is null
      *
      * @param response the {@link HttpServletResponse} to be wrapped.
+     *
+     * @throws java.lang.IllegalArgumentException if the response is null
      */
     public HttpServletResponseWrapper(HttpServletResponse response) {
         super(response);

--- a/src/main/java/javax/servlet/http/HttpUtils.java
+++ b/src/main/java/javax/servlet/http/HttpUtils.java
@@ -81,7 +81,7 @@ public class HttpUtils {
             throw new IllegalArgumentException();
         }
 
-        Hashtable<String, String[]> ht = new Hashtable<String, String[]>();
+        Hashtable<String, String[]> ht = new Hashtable<>();
         StringBuilder sb = new StringBuilder();
         StringTokenizer st = new StringTokenizer(s, "&");
         while (st.hasMoreTokens()) {
@@ -154,7 +154,7 @@ public class HttpUtils {
 	
 	if (len <=0) {
             // cheap hack to return an empty hash
-	    return new Hashtable<String, String[]>(); 
+	    return new Hashtable<>(); 
         }
 
 	if (in == null) {

--- a/src/main/java/javax/servlet/http/HttpUtils.java
+++ b/src/main/java/javax/servlet/http/HttpUtils.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/javax/servlet/http/PushBuilder.java
+++ b/src/main/java/javax/servlet/http/PushBuilder.java
@@ -102,13 +102,14 @@ public interface PushBuilder {
     /** 
      * <p>Set the method to be used for the push.</p>
      * 
+     * @param method the method to be used for the push.
+     *
      * @throws NullPointerException if the argument is {@code null}
      *
      * @throws IllegalArgumentException if the argument is the empty String,
      *         or any non-cacheable or unsafe methods defined in RFC 7231,
      *         which are POST, PUT, DELETE, CONNECT, OPTIONS and TRACE.
      *
-     * @param method the method to be used for the push.  
      * @return this builder.
      */
     public PushBuilder method(String method);

--- a/src/main/java/javax/servlet/http/PushBuilder.java
+++ b/src/main/java/javax/servlet/http/PushBuilder.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
Clean-up of warnings after opening code in Eclipse.
No functional changes (so should be safe to include in next release)
I find having a clean (i.e. no warnings) code base makes it easier to spot errors such as JavaDoc errors in future development work.
The copyright header has been updated as per Eclipse guidance for all modified files.
There is scope for further clean-up - such as consistent formatting - but that needs a community discussion to agree what we want that format to be first.