### PR TITLE
Add security text to Javadoc to fix #129

### DIFF
--- a/src/main/java/javax/servlet/ServletContext.java
+++ b/src/main/java/javax/servlet/ServletContext.java
@@ -295,6 +295,12 @@ public interface ServletContext {
      * <code>java.lang.Class.getResource</code>,
      * which looks up resources based on a class loader. This
      * method does not use class loaders.
+     * 
+     * <p>This method bypasses both implicit (no direct access to WEB-INF
+     * or META-INF) and explicit (defined by the web application) security
+     * constraints. Care should be taken both when constructing the path (e.g.
+     * avoid unsanitized user provided data) and when using the result not to
+     * create a security vulnerability in the application.
      *
      * @param path a <code>String</code> specifying
      * the path to the resource
@@ -331,6 +337,12 @@ public interface ServletContext {
      * which uses a class loader. This method allows servlet containers
      * to make a resource available
      * to a servlet from any location, without using a class loader.
+     *
+     * <p>This method bypasses both implicit (no direct access to WEB-INF
+     * or META-INF) and explicit (defined by the web application) security
+     * constraints. Care should be taken both when constructing the path (e.g.
+     * avoid unsanitized user provided data) and when using the result not to
+     * create a security vulnerability in the application.
      *
      *
      * @param path 	a <code>String</code> specifying the path

--- a/src/main/java/javax/servlet/ServletRequest.java
+++ b/src/main/java/javax/servlet/ServletRequest.java
@@ -401,6 +401,13 @@ public interface ServletRequest {
      * This method returns <code>null</code> if the servlet container
      * cannot return a <code>RequestDispatcher</code>.
      *
+     * <p>Using a RequestDispatcher, requests may be dispatched to any part of
+     * the web application bypassing both implicit (no direct access to WEB-INF
+     * or META-INF) and explicit (defined by the web application) security
+     * constraints. Unsanitized user provided data must not be used to construct
+     * the path passed to the RequestDispatcher as it is very likely to create a
+     * security vulnerability in the application.
+     *
      * <p>The difference between this method and {@link
      * ServletContext#getRequestDispatcher} is that this method can take a
      * relative path.
@@ -674,7 +681,7 @@ public interface ServletRequest {
      * <code>DispatcherType.ASYNC</code>. Finally, the dispatcher type of a
      * request dispatched to an error page by the container's error handling
      * mechanism is given as <code>DispatcherType.ERROR</code>.
-     *
+     * 
      * @return the dispatcher type of this request
      * 
      * @see DispatcherType


### PR DESCRIPTION
Fixes #129 
I didn't use the exact text suggested. I tried to make it both shorter and more explicit about the potential consequences of not using these parts of the API with care.