### PR TITLE
Format part of fix for #126 that wasn't reformatted on merge

### DIFF
--- a/src/main/java/javax/servlet/ServletContext.java
+++ b/src/main/java/javax/servlet/ServletContext.java
@@ -291,11 +291,10 @@ public interface ServletContext {
      * method allows servlet containers to make a resource available to a servlet from any location, without using a
      * class loader.
      *
-     * <p>This method bypasses both implicit (no direct access to WEB-INF
-     * or META-INF) and explicit (defined by the web application) security
-     * constraints. Care should be taken both when constructing the path (e.g.
-     * avoid unsanitized user provided data) and when using the result not to
-     * create a security vulnerability in the application.
+     * <p>
+     * This method bypasses both implicit (no direct access to WEB-INF or META-INF) and explicit (defined by the web
+     * application) security constraints. Care should be taken both when constructing the path (e.g. avoid unsanitized
+     * user provided data) and when using the result not to create a security vulnerability in the application.
      *
      *
      * @param path a <code>String</code> specifying the path to the resource


### PR DESCRIPTION
There was a conflict between the large reformat fix and the Javadoc updates. This text wasn't in conflict so the format wasn't updated.