### PR TITLE
Fixes #201 - Java JPMS modules.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,9 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                        <manifestEntries>
+                            <Automatic-Module-Name>javax.servlet.api</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                     <excludes>
                         <exclude>**/*.java</exclude>


### PR DESCRIPTION
Added Automatic-Module-Name: javax.servlet.api to the MANIFEST.

Signed-off-by: Simone Bordet <simone.bordet@gmail.com>