### PR TITLE
remove Deprecated tag as workaround for TCK signature failure 

### DIFF
--- a/api/src/main/java/javax/servlet/ServletRequest.java
+++ b/api/src/main/java/javax/servlet/ServletRequest.java
@@ -359,7 +359,6 @@ public interface ServletRequest {
      * 
      * @deprecated As of Version 2.1 of the Java Servlet API, use {@link ServletContext#getRealPath} instead.
      */
-    @Deprecated
     public String getRealPath(String path);
 
     /**


### PR DESCRIPTION
Addresses Jakarta EE 8 TCK signature test failure with master/4.0.4 branches: 
> javax.servlet.ServletRequest: getRealPath(java.lang.String):anno 0 java.lang.Deprecated())

Signed-off-by: Scott Marlow <smarlow@redhat.com>