### PR TITLE
Enable building on newer JDKs

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -46,7 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -56,8 +56,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8 or lower</message>
+                                    <version>[1.8.0,)</version>
+                                    <message>You need JDK8 or higher</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
This PR addresses two issues that were identified by building on a larger ranger of JDKs, particularly newer ones.

On the CI system (although I can't replicate it locally) some very new JDKs report java.lang.ExceptionInInitializerError. Updating latest version fixes this (at least it did for WebSocket).

The spec module added a requirement for Java 8 or lower. This doesn't seem right and prevents building on newer JDKs. Fix this by changing JDK range (to align with the range used by WebSocket).