### PR TITLE
Fix #288 add copyright checks

### DIFF
--- a/api/etc/config/copyright-exclude
+++ b/api/etc/config/copyright-exclude
@@ -1,0 +1,4 @@
+.png
+speclicense.html
+/etc/config/copyright-exclude
+/etc/config/copyright.txt

--- a/api/etc/config/copyright.txt
+++ b/api/etc/config/copyright.txt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) YYYY Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -143,6 +144,29 @@
                 </configuration>
             </plugin>
             
+            <!-- Checks copyright / license headers -->        
+            <plugin>
+                <groupId>org.glassfish.copyright</groupId>
+                <artifactId>glassfish-copyright-maven-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <excludeFile>etc/config/copyright-exclude</excludeFile>
+                    <!--svn|mercurial|git - defaults to svn-->
+                    <scm>git</scm>
+                    <!-- turn on/off debugging -->
+                    <debug>off</debug>
+                    <!-- skip files not under SCM-->
+                    <scmOnly>true</scmOnly>
+                    <!-- turn off warnings -->
+                    <warn>true</warn>
+                    <!-- for use with repair -->
+                    <update>false</update>
+                    <!-- check that year is correct -->
+                    <ignoreYear>false</ignoreYear>
+                    <templateFile>etc/config/copyright.txt</templateFile>
+                </configuration>
+            </plugin>
+
             <!-- 
                 spec-version-maven-plugin would normally appear here.
                 But somehow is missing for Servlet.

--- a/api/src/main/java/jakarta/servlet/AsyncContext.java
+++ b/api/src/main/java/jakarta/servlet/AsyncContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/AsyncEvent.java
+++ b/api/src/main/java/jakarta/servlet/AsyncEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/AsyncListener.java
+++ b/api/src/main/java/jakarta/servlet/AsyncListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/DispatcherType.java
+++ b/api/src/main/java/jakarta/servlet/DispatcherType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/Filter.java
+++ b/api/src/main/java/jakarta/servlet/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/FilterChain.java
+++ b/api/src/main/java/jakarta/servlet/FilterChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/FilterConfig.java
+++ b/api/src/main/java/jakarta/servlet/FilterConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/FilterRegistration.java
+++ b/api/src/main/java/jakarta/servlet/FilterRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/GenericFilter.java
+++ b/api/src/main/java/jakarta/servlet/GenericFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/GenericServlet.java
+++ b/api/src/main/java/jakarta/servlet/GenericServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation  
  *

--- a/api/src/main/java/jakarta/servlet/HttpConstraintElement.java
+++ b/api/src/main/java/jakarta/servlet/HttpConstraintElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/HttpMethodConstraintElement.java
+++ b/api/src/main/java/jakarta/servlet/HttpMethodConstraintElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/LocalStrings.properties
+++ b/api/src/main/java/jakarta/servlet/LocalStrings.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/LocalStrings_fr.properties
+++ b/api/src/main/java/jakarta/servlet/LocalStrings_fr.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/LocalStrings_ja.properties
+++ b/api/src/main/java/jakarta/servlet/LocalStrings_ja.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/MultipartConfigElement.java
+++ b/api/src/main/java/jakarta/servlet/MultipartConfigElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/ReadListener.java
+++ b/api/src/main/java/jakarta/servlet/ReadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/Registration.java
+++ b/api/src/main/java/jakarta/servlet/Registration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/RequestDispatcher.java
+++ b/api/src/main/java/jakarta/servlet/RequestDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/Servlet.java
+++ b/api/src/main/java/jakarta/servlet/Servlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletConfig.java
+++ b/api/src/main/java/jakarta/servlet/ServletConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletContainerInitializer.java
+++ b/api/src/main/java/jakarta/servlet/ServletContainerInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/ServletContext.java
+++ b/api/src/main/java/jakarta/servlet/ServletContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletContextAttributeEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletContextAttributeListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextAttributeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletContextEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletContextListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletException.java
+++ b/api/src/main/java/jakarta/servlet/ServletException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletInputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletOutputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletRegistration.java
+++ b/api/src/main/java/jakarta/servlet/ServletRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/ServletRequestAttributeEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestAttributeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletRequestAttributeListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestAttributeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletRequestEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletRequestListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletRequestWrapper.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletResponse.java
+++ b/api/src/main/java/jakarta/servlet/ServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletResponseWrapper.java
+++ b/api/src/main/java/jakarta/servlet/ServletResponseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/ServletSecurityElement.java
+++ b/api/src/main/java/jakarta/servlet/ServletSecurityElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/SessionCookieConfig.java
+++ b/api/src/main/java/jakarta/servlet/SessionCookieConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/SessionTrackingMode.java
+++ b/api/src/main/java/jakarta/servlet/SessionTrackingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/SingleThreadModel.java
+++ b/api/src/main/java/jakarta/servlet/SingleThreadModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/UnavailableException.java
+++ b/api/src/main/java/jakarta/servlet/UnavailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/WriteListener.java
+++ b/api/src/main/java/jakarta/servlet/WriteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/HandlesTypes.java
+++ b/api/src/main/java/jakarta/servlet/annotation/HandlesTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/HttpConstraint.java
+++ b/api/src/main/java/jakarta/servlet/annotation/HttpConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/HttpMethodConstraint.java
+++ b/api/src/main/java/jakarta/servlet/annotation/HttpMethodConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/MultipartConfig.java
+++ b/api/src/main/java/jakarta/servlet/annotation/MultipartConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/ServletSecurity.java
+++ b/api/src/main/java/jakarta/servlet/annotation/ServletSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/WebFilter.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/WebInitParam.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebInitParam.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/WebListener.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/WebServlet.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/annotation/package.html
+++ b/api/src/main/java/jakarta/servlet/annotation/package.html
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/servlet/descriptor/JspConfigDescriptor.java
+++ b/api/src/main/java/jakarta/servlet/descriptor/JspConfigDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/descriptor/JspPropertyGroupDescriptor.java
+++ b/api/src/main/java/jakarta/servlet/descriptor/JspPropertyGroupDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/descriptor/TaglibDescriptor.java
+++ b/api/src/main/java/jakarta/servlet/descriptor/TaglibDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/descriptor/package.html
+++ b/api/src/main/java/jakarta/servlet/descriptor/package.html
@@ -3,7 +3,8 @@
 <head>
 <!--
 
-    Copyright (c) 2009, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2009, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpFilter.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/HttpServlet.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponseWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponseWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSession.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionActivationListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionActivationListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionAttributeListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionAttributeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionBindingEvent.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionBindingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionBindingListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionBindingListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionContext.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionEvent.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionIdListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionIdListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/HttpUpgradeHandler.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpUpgradeHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/HttpUtils.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997-2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *

--- a/api/src/main/java/jakarta/servlet/http/LocalStrings.properties
+++ b/api/src/main/java/jakarta/servlet/http/LocalStrings.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/http/LocalStrings_es.properties
+++ b/api/src/main/java/jakarta/servlet/http/LocalStrings_es.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/http/LocalStrings_fr.properties
+++ b/api/src/main/java/jakarta/servlet/http/LocalStrings_fr.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/http/LocalStrings_ja.properties
+++ b/api/src/main/java/jakarta/servlet/http/LocalStrings_ja.properties
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+# All rights reserved.
 # Copyright 2004 The Apache Software Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/http/MappingMatch.java
+++ b/api/src/main/java/jakarta/servlet/http/MappingMatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/Part.java
+++ b/api/src/main/java/jakarta/servlet/http/Part.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/PushBuilder.java
+++ b/api/src/main/java/jakarta/servlet/http/PushBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/WebConnection.java
+++ b/api/src/main/java/jakarta/servlet/http/WebConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates and others.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the

--- a/api/src/main/java/jakarta/servlet/http/package.html
+++ b/api/src/main/java/jakarta/servlet/http/package.html
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
     Copyright 2004 The Apache Software Foundation
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/servlet/package.html
+++ b/api/src/main/java/jakarta/servlet/package.html
@@ -1,6 +1,7 @@
 <!--
 
-    Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
     Copyright 2004 The Apache Software Foundation
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/javadoc/doc-files/expert-draft-bg-blank.graffle
+++ b/api/src/main/javadoc/doc-files/expert-draft-bg-blank.graffle
@@ -2,7 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/javadoc/doc-files/expert-draft-bg-non-blank.graffle
+++ b/api/src/main/javadoc/doc-files/expert-draft-bg-non-blank.graffle
@@ -2,7 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates and others.
+    All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/api/src/main/javadoc/javax.servlet-api.css
+++ b/api/src/main/javadoc/javax.servlet-api.css
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
The plug-in first states the dates in most files needs to be updated to 2019. Do that and it then says it needs to be 2020 (because they have changed again). Given that these files are going to be released/published in 2020, I think a 2020 date is fine.

For the actual text, the plug-in complains if the "and others" part is missing. This only affected a handful of files. Looking at them, they had all been modified (or at least moved) since the initial import so the "and others" text seems justified to me.