### PR TITLE
Alternative approach for code formatting

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,4 +14,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Dvalidate-format

--- a/api/etc/config/ee4j-eclipse-formatting.xml
+++ b/api/etc/config/ee4j-eclipse-formatting.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="14">
+<profile kind="CodeFormatterProfile" name="EE4J" version="14">
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statment" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_descriptions_grouped" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="120"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_parameters" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_loops" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_simple_for_body_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_conditional_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_delcaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_type_arguments" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_simple_while_body_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="common_lines"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_simple_do_while_body_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_for_loop_header" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="160"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+</profile>
+</profiles>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -129,6 +129,19 @@
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>2.11.0</version>
+                    <configuration>
+                        <configFile>${project.basedir}/etc/config/ee4j-eclipse-formatting.xml</configFile>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>impsort-maven-plugin</artifactId>
+                    <version>1.3.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -387,6 +400,86 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
 
     <profiles>
 
+        <profile>
+            <id>format</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>!validate-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <configuration>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>sort-imports</id>
+                                <goals>
+                                    <goal>sort</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>validate</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <property>
+                    <name>validate-format</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>process-sources</phase>
+                                <goals>
+                                    <goal>validate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.revelc.code</groupId>
+                        <artifactId>impsort-maven-plugin</artifactId>
+                        <configuration>
+                            <removeUnused>true</removeUnused>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>check-imports</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>oss-release</id>
             <build>

--- a/api/src/main/java/jakarta/servlet/AsyncContext.java
+++ b/api/src/main/java/jakarta/servlet/AsyncContext.java
@@ -82,8 +82,8 @@ public interface AsyncContext {
      *
      * @return the request that was used to initialize this AsyncContext
      *
-     * @exception IllegalStateException if {@link #complete} or any of the {@link #dispatch} methods has been called in
-     *                                  the asynchronous cycle
+     * @exception IllegalStateException if {@link #complete} or any of the {@link #dispatch} methods has been called in the
+     * asynchronous cycle
      */
     public ServletRequest getRequest();
 
@@ -93,25 +93,23 @@ public interface AsyncContext {
      *
      * @return the response that was used to initialize this AsyncContext
      *
-     * @exception IllegalStateException if {@link #complete} or any of the {@link #dispatch} methods has been called in
-     *                                  the asynchronous cycle
+     * @exception IllegalStateException if {@link #complete} or any of the {@link #dispatch} methods has been called in the
+     * asynchronous cycle
      */
     public ServletResponse getResponse();
 
     /**
-     * Checks if this AsyncContext was initialized with the original or application-wrapped request and response
-     * objects.
+     * Checks if this AsyncContext was initialized with the original or application-wrapped request and response objects.
      * 
      * <p>
      * This information may be used by filters invoked in the <i>outbound</i> direction, after a request was put into
      * asynchronous mode, to determine whether any request and/or response wrappers that they added during their
-     * <i>inbound</i> invocation need to be preserved for the duration of the asynchronous operation, or may be
-     * released.
+     * <i>inbound</i> invocation need to be preserved for the duration of the asynchronous operation, or may be released.
      *
      * @return true if this AsyncContext was initialized with the original request and response objects by calling
-     *         {@link ServletRequest#startAsync()}, or if it was initialized by calling
-     *         {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}, and neither the ServletRequest nor
-     *         ServletResponse arguments carried any application-provided wrappers; false otherwise
+     * {@link ServletRequest#startAsync()}, or if it was initialized by calling
+     * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}, and neither the ServletRequest nor
+     * ServletResponse arguments carried any application-provided wrappers; false otherwise
      */
     public boolean hasOriginalRequestAndResponse();
 
@@ -119,8 +117,8 @@ public interface AsyncContext {
      * Dispatches the request and response objects of this AsyncContext to the servlet container.
      * 
      * <p>
-     * If the asynchronous cycle was started with {@link ServletRequest#startAsync(ServletRequest, ServletResponse)},
-     * and the request passed is an instance of HttpServletRequest, then the dispatch is to the URI returned by
+     * If the asynchronous cycle was started with {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}, and
+     * the request passed is an instance of HttpServletRequest, then the dispatch is to the URI returned by
      * {@link jakarta.servlet.http.HttpServletRequest#getRequestURI}. Otherwise, the dispatch is to the URI of the request
      * when it was last dispatched by the container.
      *
@@ -156,9 +154,9 @@ public interface AsyncContext {
      *
      * <p>
      * This method returns immediately after passing the request and response objects to a container managed thread, on
-     * which the dispatch operation will be performed. If this method is called before the container-initiated dispatch
-     * that called <tt>startAsync</tt> has returned to the container, the dispatch operation will be delayed until after
-     * the container-initiated dispatch has returned to the container.
+     * which the dispatch operation will be performed. If this method is called before the container-initiated dispatch that
+     * called <tt>startAsync</tt> has returned to the container, the dispatch operation will be delayed until after the
+     * container-initiated dispatch has returned to the container.
      *
      * <p>
      * The dispatcher type of the request is set to <tt>DispatcherType.ASYNC</tt>. Unlike
@@ -166,8 +164,8 @@ public interface AsyncContext {
      * headers will not be reset, and it is legal to dispatch even if the response has already been committed.
      *
      * <p>
-     * Control over the request and response is delegated to the dispatch target, and the response will be closed when
-     * the dispatch target has completed execution, unless {@link ServletRequest#startAsync()} or
+     * Control over the request and response is delegated to the dispatch target, and the response will be closed when the
+     * dispatch target has completed execution, unless {@link ServletRequest#startAsync()} or
      * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)} are called.
      * 
      * <p>
@@ -175,25 +173,23 @@ public interface AsyncContext {
      * container, as follows:
      * <ol>
      * <li>Invoke, at their {@link AsyncListener#onError onError} method, all {@link AsyncListener} instances registered
-     * with the ServletRequest for which this AsyncContext was created, and make the caught <tt>Throwable</tt> available
-     * via {@link AsyncEvent#getThrowable}.</li>
+     * with the ServletRequest for which this AsyncContext was created, and make the caught <tt>Throwable</tt> available via
+     * {@link AsyncEvent#getThrowable}.</li>
      * <li>If none of the listeners called {@link #complete} or any of the {@link #dispatch} methods, perform an error
      * dispatch with a status code equal to <tt>HttpServletResponse.SC_INTERNAL_SERVER_ERROR</tt>, and make the above
-     * <tt>Throwable</tt> available as the value of the <tt>RequestDispatcher.ERROR_EXCEPTION</tt> request
-     * attribute.</li>
+     * <tt>Throwable</tt> available as the value of the <tt>RequestDispatcher.ERROR_EXCEPTION</tt> request attribute.</li>
      * <li>If no matching error page was found, or the error page did not call {@link #complete} or any of the
      * {@link #dispatch} methods, call {@link #complete}.</li>
      * </ol>
      *
      * <p>
-     * There can be at most one asynchronous dispatch operation per asynchronous cycle, which is started by a call to
-     * one of the {@link ServletRequest#startAsync} methods. Any attempt to perform an additional asynchronous dispatch
-     * operation within the same asynchronous cycle will result in an IllegalStateException. If startAsync is
-     * subsequently called on the dispatched request, then any of the dispatch or {@link #complete} methods may be
-     * called.
+     * There can be at most one asynchronous dispatch operation per asynchronous cycle, which is started by a call to one of
+     * the {@link ServletRequest#startAsync} methods. Any attempt to perform an additional asynchronous dispatch operation
+     * within the same asynchronous cycle will result in an IllegalStateException. If startAsync is subsequently called on
+     * the dispatched request, then any of the dispatch or {@link #complete} methods may be called.
      *
-     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not
-     *                               been called during the resulting dispatch, or if {@link #complete} was called
+     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not been
+     * called during the resulting dispatch, or if {@link #complete} was called
      *
      * @see ServletRequest#getDispatcherType
      */
@@ -203,32 +199,30 @@ public interface AsyncContext {
      * Dispatches the request and response objects of this AsyncContext to the given <tt>path</tt>.
      *
      * <p>
-     * The <tt>path</tt> parameter is interpreted in the same way as in
-     * {@link ServletRequest#getRequestDispatcher(String)}, within the scope of the {@link ServletContext} from which
-     * this AsyncContext was initialized.
+     * The <tt>path</tt> parameter is interpreted in the same way as in {@link ServletRequest#getRequestDispatcher(String)},
+     * within the scope of the {@link ServletContext} from which this AsyncContext was initialized.
      *
      * <p>
      * All path related query methods of the request must reflect the dispatch target, while the original request URI,
      * context path, path info, servlet path, and query string may be recovered from the {@link #ASYNC_REQUEST_URI},
-     * {@link #ASYNC_CONTEXT_PATH}, {@link #ASYNC_PATH_INFO}, {@link #ASYNC_SERVLET_PATH}, and
-     * {@link #ASYNC_QUERY_STRING} attributes of the request. These attributes will always reflect the original path
-     * elements, even under repeated dispatches.
+     * {@link #ASYNC_CONTEXT_PATH}, {@link #ASYNC_PATH_INFO}, {@link #ASYNC_SERVLET_PATH}, and {@link #ASYNC_QUERY_STRING}
+     * attributes of the request. These attributes will always reflect the original path elements, even under repeated
+     * dispatches.
      *
      * <p>
-     * There can be at most one asynchronous dispatch operation per asynchronous cycle, which is started by a call to
-     * one of the {@link ServletRequest#startAsync} methods. Any attempt to perform an additional asynchronous dispatch
-     * operation within the same asynchronous cycle will result in an IllegalStateException. If startAsync is
-     * subsequently called on the dispatched request, then any of the dispatch or {@link #complete} methods may be
-     * called.
+     * There can be at most one asynchronous dispatch operation per asynchronous cycle, which is started by a call to one of
+     * the {@link ServletRequest#startAsync} methods. Any attempt to perform an additional asynchronous dispatch operation
+     * within the same asynchronous cycle will result in an IllegalStateException. If startAsync is subsequently called on
+     * the dispatched request, then any of the dispatch or {@link #complete} methods may be called.
      *
      * <p>
      * See {@link #dispatch()} for additional details, including error handling.
      *
      * @param path the path of the dispatch target, scoped to the ServletContext from which this AsyncContext was
-     *             initialized
+     * initialized
      *
-     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not
-     *                               been called during the resulting dispatch, or if {@link #complete} was called
+     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not been
+     * called during the resulting dispatch, or if {@link #complete} was called
      *
      * @see ServletRequest#getDispatcherType
      */
@@ -239,50 +233,49 @@ public interface AsyncContext {
      * <tt>context</tt>.
      *
      * <p>
-     * The <tt>path</tt> parameter is interpreted in the same way as in
-     * {@link ServletRequest#getRequestDispatcher(String)}, except that it is scoped to the given <tt>context</tt>.
+     * The <tt>path</tt> parameter is interpreted in the same way as in {@link ServletRequest#getRequestDispatcher(String)},
+     * except that it is scoped to the given <tt>context</tt>.
      *
      * <p>
      * All path related query methods of the request must reflect the dispatch target, while the original request URI,
      * context path, path info, servlet path, and query string may be recovered from the {@link #ASYNC_REQUEST_URI},
-     * {@link #ASYNC_CONTEXT_PATH}, {@link #ASYNC_PATH_INFO}, {@link #ASYNC_SERVLET_PATH}, and
-     * {@link #ASYNC_QUERY_STRING} attributes of the request. These attributes will always reflect the original path
-     * elements, even under repeated dispatches.
+     * {@link #ASYNC_CONTEXT_PATH}, {@link #ASYNC_PATH_INFO}, {@link #ASYNC_SERVLET_PATH}, and {@link #ASYNC_QUERY_STRING}
+     * attributes of the request. These attributes will always reflect the original path elements, even under repeated
+     * dispatches.
      *
      * <p>
-     * There can be at most one asynchronous dispatch operation per asynchronous cycle, which is started by a call to
-     * one of the {@link ServletRequest#startAsync} methods. Any attempt to perform an additional asynchronous dispatch
-     * operation within the same asynchronous cycle will result in an IllegalStateException. If startAsync is
-     * subsequently called on the dispatched request, then any of the dispatch or {@link #complete} methods may be
-     * called.
+     * There can be at most one asynchronous dispatch operation per asynchronous cycle, which is started by a call to one of
+     * the {@link ServletRequest#startAsync} methods. Any attempt to perform an additional asynchronous dispatch operation
+     * within the same asynchronous cycle will result in an IllegalStateException. If startAsync is subsequently called on
+     * the dispatched request, then any of the dispatch or {@link #complete} methods may be called.
      *
      * <p>
      * See {@link #dispatch()} for additional details, including error handling.
      *
      * @param context the ServletContext of the dispatch target
-     * @param path    the path of the dispatch target, scoped to the given ServletContext
+     * @param path the path of the dispatch target, scoped to the given ServletContext
      *
-     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not
-     *                               been called during the resulting dispatch, or if {@link #complete} was called
+     * @throws IllegalStateException if one of the dispatch methods has been called and the startAsync method has not been
+     * called during the resulting dispatch, or if {@link #complete} was called
      *
      * @see ServletRequest#getDispatcherType
      */
     public void dispatch(ServletContext context, String path);
 
     /**
-     * Completes the asynchronous operation that was started on the request that was used to initialze this
-     * AsyncContext, closing the response that was used to initialize this AsyncContext.
+     * Completes the asynchronous operation that was started on the request that was used to initialze this AsyncContext,
+     * closing the response that was used to initialize this AsyncContext.
      *
      * <p>
-     * Any listeners of type {@link AsyncListener} that were registered with the ServletRequest for which this
-     * AsyncContext was created will be invoked at their {@link AsyncListener#onComplete(AsyncEvent) onComplete} method.
+     * Any listeners of type {@link AsyncListener} that were registered with the ServletRequest for which this AsyncContext
+     * was created will be invoked at their {@link AsyncListener#onComplete(AsyncEvent) onComplete} method.
      *
      * <p>
      * It is legal to call this method any time after a call to {@link ServletRequest#startAsync()} or
-     * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}, and before a call to one of the
-     * <tt>dispatch</tt> methods of this class. If this method is called before the container-initiated dispatch that
-     * called <tt>startAsync</tt> has returned to the container, then the call will not take effect (and any invocations
-     * of {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after the container-initiated dispatch has
+     * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}, and before a call to one of the <tt>dispatch</tt>
+     * methods of this class. If this method is called before the container-initiated dispatch that called
+     * <tt>startAsync</tt> has returned to the container, then the call will not take effect (and any invocations of
+     * {@link AsyncListener#onComplete(AsyncEvent)} will be delayed) until after the container-initiated dispatch has
      * returned to the container.
      */
     public void complete();
@@ -296,37 +289,36 @@ public interface AsyncContext {
     public void start(Runnable run);
 
     /**
-     * Registers the given {@link AsyncListener} with the most recent asynchronous cycle that was started by a call to
-     * one of the {@link ServletRequest#startAsync} methods.
+     * Registers the given {@link AsyncListener} with the most recent asynchronous cycle that was started by a call to one
+     * of the {@link ServletRequest#startAsync} methods.
      *
      * <p>
-     * The given AsyncListener will receive an {@link AsyncEvent} when the asynchronous cycle completes successfully,
-     * times out, results in an error, or a new asynchronous cycle is being initiated via one of the
+     * The given AsyncListener will receive an {@link AsyncEvent} when the asynchronous cycle completes successfully, times
+     * out, results in an error, or a new asynchronous cycle is being initiated via one of the
      * {@link ServletRequest#startAsync} methods.
      *
      * <p>
      * AsyncListener instances will be notified in the order in which they were added.
      *
      * <p>
-     * If {@link ServletRequest#startAsync(ServletRequest, ServletResponse)} or {@link ServletRequest#startAsync} is
-     * called, the exact same request and response objects are available from the {@link AsyncEvent} when the
-     * {@link AsyncListener} is notified.
+     * If {@link ServletRequest#startAsync(ServletRequest, ServletResponse)} or {@link ServletRequest#startAsync} is called,
+     * the exact same request and response objects are available from the {@link AsyncEvent} when the {@link AsyncListener}
+     * is notified.
      *
      * @param listener the AsyncListener to be registered
      * 
-     * @throws IllegalStateException if this method is called after the container-initiated dispatch, during which one
-     *                               of the {@link ServletRequest#startAsync} methods was called, has returned to the
-     *                               container
+     * @throws IllegalStateException if this method is called after the container-initiated dispatch, during which one of
+     * the {@link ServletRequest#startAsync} methods was called, has returned to the container
      */
     public void addListener(AsyncListener listener);
 
     /**
-     * Registers the given {@link AsyncListener} with the most recent asynchronous cycle that was started by a call to
-     * one of the {@link ServletRequest#startAsync} methods.
+     * Registers the given {@link AsyncListener} with the most recent asynchronous cycle that was started by a call to one
+     * of the {@link ServletRequest#startAsync} methods.
      *
      * <p>
-     * The given AsyncListener will receive an {@link AsyncEvent} when the asynchronous cycle completes successfully,
-     * times out, results in an error, or a new asynchronous cycle is being initiated via one of the
+     * The given AsyncListener will receive an {@link AsyncEvent} when the asynchronous cycle completes successfully, times
+     * out, results in an error, or a new asynchronous cycle is being initiated via one of the
      * {@link ServletRequest#startAsync} methods.
      *
      * <p>
@@ -335,18 +327,17 @@ public interface AsyncContext {
      * <p>
      * The given ServletRequest and ServletResponse objects will be made available to the given AsyncListener via the
      * {@link AsyncEvent#getSuppliedRequest getSuppliedRequest} and {@link AsyncEvent#getSuppliedResponse
-     * getSuppliedResponse} methods, respectively, of the {@link AsyncEvent} delivered to it. These objects should not
-     * be read from or written to, respectively, at the time the AsyncEvent is delivered, because additional wrapping
-     * may have occurred since the given AsyncListener was registered, but may be used in order to release any resources
-     * associated with them.
+     * getSuppliedResponse} methods, respectively, of the {@link AsyncEvent} delivered to it. These objects should not be
+     * read from or written to, respectively, at the time the AsyncEvent is delivered, because additional wrapping may have
+     * occurred since the given AsyncListener was registered, but may be used in order to release any resources associated
+     * with them.
      *
-     * @param listener        the AsyncListener to be registered
-     * @param servletRequest  the ServletRequest that will be included in the AsyncEvent
+     * @param listener the AsyncListener to be registered
+     * @param servletRequest the ServletRequest that will be included in the AsyncEvent
      * @param servletResponse the ServletResponse that will be included in the AsyncEvent
      *
-     * @throws IllegalStateException if this method is called after the container-initiated dispatch, during which one
-     *                               of the {@link ServletRequest#startAsync} methods was called, has returned to the
-     *                               container
+     * @throws IllegalStateException if this method is called after the container-initiated dispatch, during which one of
+     * the {@link ServletRequest#startAsync} methods was called, has returned to the container
      */
     public void addListener(AsyncListener listener, ServletRequest servletRequest, ServletResponse servletResponse);
 
@@ -354,8 +345,8 @@ public interface AsyncContext {
      * Instantiates the given {@link AsyncListener} class.
      *
      * <p>
-     * The returned AsyncListener instance may be further customized before it is registered with this AsyncContext via
-     * a call to one of the <code>addListener</code> methods.
+     * The returned AsyncListener instance may be further customized before it is registered with this AsyncContext via a
+     * call to one of the <code>addListener</code> methods.
      *
      * <p>
      * The given AsyncListener class must define a zero argument constructor, which is used to instantiate it.
@@ -367,7 +358,7 @@ public interface AsyncContext {
      * <p>
      * This method supports any annotations applicable to AsyncListener.
      *
-     * @param       <T> the class of the object to instantiate
+     * @param <T> the class of the object to instantiate
      * @param clazz the AsyncListener class to instantiate
      *
      * @return the new AsyncListener instance
@@ -384,8 +375,8 @@ public interface AsyncContext {
      * {@link ServletRequest#startAsync} methods was called has returned to the container.
      *
      * <p>
-     * The timeout will expire if neither the {@link #complete} method nor any of the dispatch methods are called. A
-     * timeout value of zero or less indicates no timeout.
+     * The timeout will expire if neither the {@link #complete} method nor any of the dispatch methods are called. A timeout
+     * value of zero or less indicates no timeout.
      * 
      * <p>
      * If {@link #setTimeout} is not called, then the container's default timeout, which is available via a call to
@@ -396,9 +387,8 @@ public interface AsyncContext {
      *
      * @param timeout the timeout in milliseconds
      *
-     * @throws IllegalStateException if this method is called after the container-initiated dispatch, during which one
-     *                               of the {@link ServletRequest#startAsync} methods was called, has returned to the
-     *                               container
+     * @throws IllegalStateException if this method is called after the container-initiated dispatch, during which one of
+     * the {@link ServletRequest#startAsync} methods was called, has returned to the container
      */
     public void setTimeout(long timeout);
 
@@ -406,8 +396,8 @@ public interface AsyncContext {
      * Gets the timeout (in milliseconds) for this AsyncContext.
      *
      * <p>
-     * This method returns the container's default timeout for asynchronous operations, or the timeout value passed to
-     * the most recent invocation of {@link #setTimeout}.
+     * This method returns the container's default timeout for asynchronous operations, or the timeout value passed to the
+     * most recent invocation of {@link #setTimeout}.
      *
      * <p>
      * A timeout value of zero or less indicates no timeout.

--- a/api/src/main/java/jakarta/servlet/AsyncEvent.java
+++ b/api/src/main/java/jakarta/servlet/AsyncEvent.java
@@ -43,8 +43,8 @@ public class AsyncEvent {
     /**
      * Constructs an AsyncEvent from the given AsyncContext, ServletRequest, and ServletResponse.
      *
-     * @param context  the AsyncContex to be delivered with this AsyncEvent
-     * @param request  the ServletRequest to be delivered with this AsyncEvent
+     * @param context the AsyncContex to be delivered with this AsyncEvent
+     * @param request the ServletRequest to be delivered with this AsyncEvent
      * @param response the ServletResponse to be delivered with this AsyncEvent
      */
     public AsyncEvent(AsyncContext context, ServletRequest request, ServletResponse response) {
@@ -54,7 +54,7 @@ public class AsyncEvent {
     /**
      * Constructs an AsyncEvent from the given AsyncContext and Throwable.
      *
-     * @param context   the AsyncContex to be delivered with this AsyncEvent
+     * @param context the AsyncContex to be delivered with this AsyncEvent
      * @param throwable the Throwable to be delivered with this AsyncEvent
      */
     public AsyncEvent(AsyncContext context, Throwable throwable) {
@@ -64,9 +64,9 @@ public class AsyncEvent {
     /**
      * Constructs an AsyncEvent from the given AsyncContext, ServletRequest, ServletResponse, and Throwable.
      *
-     * @param context   the AsyncContex to be delivered with this AsyncEvent
-     * @param request   the ServletRequest to be delivered with this AsyncEvent
-     * @param response  the ServletResponse to be delivered with this AsyncEvent
+     * @param context the AsyncContex to be delivered with this AsyncEvent
+     * @param request the ServletRequest to be delivered with this AsyncEvent
+     * @param response the ServletResponse to be delivered with this AsyncEvent
      * @param throwable the Throwable to be delivered with this AsyncEvent
      */
     public AsyncEvent(AsyncContext context, ServletRequest request, ServletResponse response, Throwable throwable) {
@@ -90,12 +90,12 @@ public class AsyncEvent {
      *
      * <p>
      * If the AsyncListener to which this AsyncEvent is being delivered was added using
-     * {@link AsyncContext#addListener(AsyncListener, ServletRequest, ServletResponse)}, the returned ServletRequest
-     * will be the same as the one supplied to the above method. If the AsyncListener was added via
+     * {@link AsyncContext#addListener(AsyncListener, ServletRequest, ServletResponse)}, the returned ServletRequest will be
+     * the same as the one supplied to the above method. If the AsyncListener was added via
      * {@link AsyncContext#addListener(AsyncListener)}, this method must return null.
      *
-     * @return the ServletRequest that was used to initialize this AsyncEvent, or null if this AsyncEvent was
-     *         initialized without any ServletRequest
+     * @return the ServletRequest that was used to initialize this AsyncEvent, or null if this AsyncEvent was initialized
+     * without any ServletRequest
      */
     public ServletRequest getSuppliedRequest() {
         return request;
@@ -106,12 +106,12 @@ public class AsyncEvent {
      *
      * <p>
      * If the AsyncListener to which this AsyncEvent is being delivered was added using
-     * {@link AsyncContext#addListener(AsyncListener, ServletRequest, ServletResponse)}, the returned ServletResponse
-     * will be the same as the one supplied to the above method. If the AsyncListener was added via
+     * {@link AsyncContext#addListener(AsyncListener, ServletRequest, ServletResponse)}, the returned ServletResponse will
+     * be the same as the one supplied to the above method. If the AsyncListener was added via
      * {@link AsyncContext#addListener(AsyncListener)}, this method must return null.
      *
-     * @return the ServletResponse that was used to initialize this AsyncEvent, or null if this AsyncEvent was
-     *         initialized without any ServletResponse
+     * @return the ServletResponse that was used to initialize this AsyncEvent, or null if this AsyncEvent was initialized
+     * without any ServletResponse
      */
     public ServletResponse getSuppliedResponse() {
         return response;
@@ -120,8 +120,8 @@ public class AsyncEvent {
     /**
      * Gets the Throwable from this AsyncEvent.
      *
-     * @return the Throwable that was used to initialize this AsyncEvent, or null if this AsyncEvent was initialized
-     *         without any Throwable
+     * @return the Throwable that was used to initialize this AsyncEvent, or null if this AsyncEvent was initialized without
+     * any Throwable
      */
     public Throwable getThrowable() {
         return throwable;

--- a/api/src/main/java/jakarta/servlet/AsyncListener.java
+++ b/api/src/main/java/jakarta/servlet/AsyncListener.java
@@ -51,8 +51,8 @@ public interface AsyncListener extends EventListener {
      * Notifies this AsyncListener that an asynchronous operation has timed out.
      * 
      * <p>
-     * The {@link AsyncContext} corresponding to the asynchronous operation that has timed out may be obtained by
-     * calling {@link AsyncEvent#getAsyncContext getAsyncContext} on the given <tt>event</tt>.
+     * The {@link AsyncContext} corresponding to the asynchronous operation that has timed out may be obtained by calling
+     * {@link AsyncEvent#getAsyncContext getAsyncContext} on the given <tt>event</tt>.
      *
      * <p>
      * In addition, if this AsyncListener had been registered via a call to
@@ -90,8 +90,8 @@ public interface AsyncListener extends EventListener {
      * {@link ServletRequest#startAsync} methods.
      *
      * <p>
-     * The {@link AsyncContext} corresponding to the asynchronous operation that is being reinitialized may be obtained
-     * by calling {@link AsyncEvent#getAsyncContext getAsyncContext} on the given <tt>event</tt>.
+     * The {@link AsyncContext} corresponding to the asynchronous operation that is being reinitialized may be obtained by
+     * calling {@link AsyncEvent#getAsyncContext getAsyncContext} on the given <tt>event</tt>.
      * 
      * <p>
      * In addition, if this AsyncListener had been registered via a call to
@@ -100,9 +100,8 @@ public interface AsyncListener extends EventListener {
      * {@link AsyncEvent#getSuppliedResponse getSuppliedResponse}, respectively, on the given <tt>event</tt>.
      *
      * <p>
-     * This AsyncListener will not receive any events related to the new asynchronous cycle unless it registers itself
-     * (via a call to {@link AsyncContext#addListener}) with the AsyncContext that is delivered as part of the given
-     * AsyncEvent.
+     * This AsyncListener will not receive any events related to the new asynchronous cycle unless it registers itself (via
+     * a call to {@link AsyncContext#addListener}) with the AsyncContext that is delivered as part of the given AsyncEvent.
      *
      * @param event the AsyncEvent indicating that a new asynchronous cycle is being initiated
      *

--- a/api/src/main/java/jakarta/servlet/Filter.java
+++ b/api/src/main/java/jakarta/servlet/Filter.java
@@ -73,23 +73,22 @@ public interface Filter {
      * @implSpec The default implementation takes no action.
      *
      * @param filterConfig a <code>FilterConfig</code> object containing the filter's configuration and initialization
-     *                     parameters
+     * parameters
      * @throws ServletException if an exception has occurred that interferes with the filter's normal operation
      */
     default public void init(FilterConfig filterConfig) throws ServletException {
     }
 
     /**
-     * The <code>doFilter</code> method of the Filter is called by the container each time a request/response pair is
-     * passed through the chain due to a client request for a resource at the end of the chain. The FilterChain passed
-     * in to this method allows the Filter to pass on the request and response to the next entity in the chain.
+     * The <code>doFilter</code> method of the Filter is called by the container each time a request/response pair is passed
+     * through the chain due to a client request for a resource at the end of the chain. The FilterChain passed in to this
+     * method allows the Filter to pass on the request and response to the next entity in the chain.
      *
      * <p>
      * A typical implementation of this method would follow the following pattern:
      * <ol>
      * <li>Examine the request
-     * <li>Optionally wrap the request object with a custom implementation to filter content or headers for input
-     * filtering
+     * <li>Optionally wrap the request object with a custom implementation to filter content or headers for input filtering
      * <li>Optionally wrap the response object with a custom implementation to filter content or headers for output
      * filtering
      * <li>
@@ -102,10 +101,10 @@ public interface Filter {
      * <li>Directly set headers on the response after invocation of the next entity in the filter chain.
      * </ol>
      *
-     * @param request  the <code>ServletRequest</code> object contains the client's request
+     * @param request the <code>ServletRequest</code> object contains the client's request
      * @param response the <code>ServletResponse</code> object contains the filter's response
-     * @param chain    the <code>FilterChain</code> for invoking the next filter or the resource
-     * @throws IOException      if an I/O related error has occurred during the processing
+     * @param chain the <code>FilterChain</code> for invoking the next filter or the resource
+     * @throws IOException if an I/O related error has occurred during the processing
      * @throws ServletException if an exception occurs that interferes with the filter's normal operation
      *
      * @see UnavailableException
@@ -119,15 +118,14 @@ public interface Filter {
      * </p>
      *
      * <p>
-     * This method is only called once all threads within the filter's doFilter method have exited or after a timeout
-     * period has passed. After the web container calls this method, it will not call the doFilter method again on this
-     * instance of the filter.
+     * This method is only called once all threads within the filter's doFilter method have exited or after a timeout period
+     * has passed. After the web container calls this method, it will not call the doFilter method again on this instance of
+     * the filter.
      * </p>
      *
      * <p>
-     * This method gives the filter an opportunity to clean up any resources that are being held (for example, memory,
-     * file handles, threads) and make sure that any persistent state is synchronized with the filter's current state in
-     * memory.
+     * This method gives the filter an opportunity to clean up any resources that are being held (for example, memory, file
+     * handles, threads) and make sure that any persistent state is synchronized with the filter's current state in memory.
      * </p>
      * 
      * @implSpec The default implementation takes no action.

--- a/api/src/main/java/jakarta/servlet/FilterChain.java
+++ b/api/src/main/java/jakarta/servlet/FilterChain.java
@@ -31,12 +31,12 @@ import java.io.IOException;
 public interface FilterChain {
 
     /**
-     * Causes the next filter in the chain to be invoked, or if the calling filter is the last filter in the chain,
-     * causes the resource at the end of the chain to be invoked.
+     * Causes the next filter in the chain to be invoked, or if the calling filter is the last filter in the chain, causes
+     * the resource at the end of the chain to be invoked.
      *
-     * @param request  the request to pass along the chain.
+     * @param request the request to pass along the chain.
      * @param response the response to pass along the chain.
-     * @throws IOException      if an I/O related error has occurred during the processing
+     * @throws IOException if an I/O related error has occurred during the processing
      * @throws ServletException if an exception has occurred that interferes with the filterChain's normal operation
      */
     public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException;

--- a/api/src/main/java/jakarta/servlet/FilterConfig.java
+++ b/api/src/main/java/jakarta/servlet/FilterConfig.java
@@ -45,13 +45,13 @@ public interface FilterConfig {
     public ServletContext getServletContext();
 
     /**
-     * Returns a <code>String</code> containing the value of the named initialization parameter, or <code>null</code> if
-     * the initialization parameter does not exist.
+     * Returns a <code>String</code> containing the value of the named initialization parameter, or <code>null</code> if the
+     * initialization parameter does not exist.
      *
      * @param name a <code>String</code> specifying the name of the initialization parameter
      *
      * @return a <code>String</code> containing the value of the initialization parameter, or <code>null</code> if the
-     *         initialization parameter does not exist
+     * initialization parameter does not exist
      */
     public String getInitParameter(String name);
 
@@ -60,7 +60,7 @@ public interface FilterConfig {
      * objects, or an empty <code>Enumeration</code> if the filter has no initialization parameters.
      *
      * @return an <code>Enumeration</code> of <code>String</code> objects containing the names of the filter's
-     *         initialization parameters
+     * initialization parameters
      */
     public Enumeration<String> getInitParameterNames();
 

--- a/api/src/main/java/jakarta/servlet/FilterRegistration.java
+++ b/api/src/main/java/jakarta/servlet/FilterRegistration.java
@@ -34,37 +34,35 @@ public interface FilterRegistration extends Registration {
      * Filter mappings are matched in the order in which they were added.
      * 
      * <p>
-     * Depending on the value of the <tt>isMatchAfter</tt> parameter, the given filter mapping will be considered after
-     * or before any <i>declared</i> filter mappings of the ServletContext from which this FilterRegistration was
-     * obtained.
+     * Depending on the value of the <tt>isMatchAfter</tt> parameter, the given filter mapping will be considered after or
+     * before any <i>declared</i> filter mappings of the ServletContext from which this FilterRegistration was obtained.
      *
      * <p>
      * If this method is called multiple times, each successive call adds to the effects of the former.
      *
      * @param dispatcherTypes the dispatcher types of the filter mapping, or null if the default
-     *                        <tt>DispatcherType.REQUEST</tt> is to be used
-     * @param isMatchAfter    true if the given filter mapping should be matched after any declared filter mappings, and
-     *                        false if it is supposed to be matched before any declared filter mappings of the
-     *                        ServletContext from which this FilterRegistration was obtained
-     * @param servletNames    the servlet names of the filter mapping
+     * <tt>DispatcherType.REQUEST</tt> is to be used
+     * @param isMatchAfter true if the given filter mapping should be matched after any declared filter mappings, and false
+     * if it is supposed to be matched before any declared filter mappings of the ServletContext from which this
+     * FilterRegistration was obtained
+     * @param servletNames the servlet names of the filter mapping
      *
      * @throws IllegalArgumentException if <tt>servletNames</tt> is null or empty
-     * @throws IllegalStateException    if the ServletContext from which this FilterRegistration was obtained has
-     *                                  already been initialized
+     * @throws IllegalStateException if the ServletContext from which this FilterRegistration was obtained has already been
+     * initialized
      */
     public void addMappingForServletNames(EnumSet<DispatcherType> dispatcherTypes, boolean isMatchAfter,
             String... servletNames);
 
     /**
-     * Gets the currently available servlet name mappings of the Filter represented by this
-     * <code>FilterRegistration</code>.
+     * Gets the currently available servlet name mappings of the Filter represented by this <code>FilterRegistration</code>.
      *
      * <p>
      * If permitted, any changes to the returned <code>Collection</code> must not affect this
      * <code>FilterRegistration</code>.
      *
      * @return a (possibly empty) <code>Collection</code> of the currently available servlet name mappings of the Filter
-     *         represented by this <code>FilterRegistration</code>
+     * represented by this <code>FilterRegistration</code>
      */
     public Collection<String> getServletNameMappings();
 
@@ -76,37 +74,35 @@ public interface FilterRegistration extends Registration {
      * Filter mappings are matched in the order in which they were added.
      * 
      * <p>
-     * Depending on the value of the <tt>isMatchAfter</tt> parameter, the given filter mapping will be considered after
-     * or before any <i>declared</i> filter mappings of the ServletContext from which this FilterRegistration was
-     * obtained.
+     * Depending on the value of the <tt>isMatchAfter</tt> parameter, the given filter mapping will be considered after or
+     * before any <i>declared</i> filter mappings of the ServletContext from which this FilterRegistration was obtained.
      *
      * <p>
      * If this method is called multiple times, each successive call adds to the effects of the former.
      *
      * @param dispatcherTypes the dispatcher types of the filter mapping, or null if the default
-     *                        <tt>DispatcherType.REQUEST</tt> is to be used
-     * @param isMatchAfter    true if the given filter mapping should be matched after any declared filter mappings, and
-     *                        false if it is supposed to be matched before any declared filter mappings of the
-     *                        ServletContext from which this FilterRegistration was obtained
-     * @param urlPatterns     the url patterns of the filter mapping
+     * <tt>DispatcherType.REQUEST</tt> is to be used
+     * @param isMatchAfter true if the given filter mapping should be matched after any declared filter mappings, and false
+     * if it is supposed to be matched before any declared filter mappings of the ServletContext from which this
+     * FilterRegistration was obtained
+     * @param urlPatterns the url patterns of the filter mapping
      *
      * @throws IllegalArgumentException if <tt>urlPatterns</tt> is null or empty
-     * @throws IllegalStateException    if the ServletContext from which this FilterRegistration was obtained has
-     *                                  already been initialized
+     * @throws IllegalStateException if the ServletContext from which this FilterRegistration was obtained has already been
+     * initialized
      */
     public void addMappingForUrlPatterns(EnumSet<DispatcherType> dispatcherTypes, boolean isMatchAfter,
             String... urlPatterns);
 
     /**
-     * Gets the currently available URL pattern mappings of the Filter represented by this
-     * <code>FilterRegistration</code>.
+     * Gets the currently available URL pattern mappings of the Filter represented by this <code>FilterRegistration</code>.
      *
      * <p>
      * If permitted, any changes to the returned <code>Collection</code> must not affect this
      * <code>FilterRegistration</code>.
      *
      * @return a (possibly empty) <code>Collection</code> of the currently available URL pattern mappings of the Filter
-     *         represented by this <code>FilterRegistration</code>
+     * represented by this <code>FilterRegistration</code>
      */
     public Collection<String> getUrlPatternMappings();
 

--- a/api/src/main/java/jakarta/servlet/GenericFilter.java
+++ b/api/src/main/java/jakarta/servlet/GenericFilter.java
@@ -64,8 +64,8 @@ public abstract class GenericFilter implements Filter, FilterConfig, java.io.Ser
 
     /**
      * <p>
-     * Returns a <code>String</code> containing the value of the named initialization parameter, or <code>null</code> if
-     * the parameter does not exist. See {@link FilterConfig#getInitParameter}.
+     * Returns a <code>String</code> containing the value of the named initialization parameter, or <code>null</code> if the
+     * parameter does not exist. See {@link FilterConfig#getInitParameter}.
      * </p>
      *
      * <p>
@@ -100,8 +100,8 @@ public abstract class GenericFilter implements Filter, FilterConfig, java.io.Ser
      * This method is supplied for convenience. It gets the parameter names from the filter's <code>FilterConfig</code>
      * object.
      *
-     * @return Enumeration an enumeration of <code>String</code> objects containing the names of the filter's
-     *         initialization parameters
+     * @return Enumeration an enumeration of <code>String</code> objects containing the names of the filter's initialization
+     * parameters
      *
      * @since Servlet 4.0
      */
@@ -137,8 +137,7 @@ public abstract class GenericFilter implements Filter, FilterConfig, java.io.Ser
      * <p>
      * This method is supplied for convenience. It gets the context from the filter's <code>FilterConfig</code> object.
      *
-     * @return ServletContext the <code>ServletContext</code> object passed to this filter by the <code>init</code>
-     *         method
+     * @return ServletContext the <code>ServletContext</code> object passed to this filter by the <code>init</code> method
      *
      * @since Servlet 4.0
      */
@@ -159,8 +158,8 @@ public abstract class GenericFilter implements Filter, FilterConfig, java.io.Ser
      * </p>
      * 
      * <p>
-     * This implementation stores the {@link FilterConfig} object it receives from the servlet container for later use.
-     * When overriding this form of the method, call <code>super.init(config)</code>.
+     * This implementation stores the {@link FilterConfig} object it receives from the servlet container for later use. When
+     * overriding this form of the method, call <code>super.init(config)</code>.
      * 
      * @param config the <code>FilterConfig</code> object that contains configuration information for this filter
      *
@@ -183,8 +182,8 @@ public abstract class GenericFilter implements Filter, FilterConfig, java.io.Ser
      *
      * <p>
      * Instead of overriding {@link #init(FilterConfig)}, simply override this method and it will be called by
-     * <code>GenericFilter.init(FilterConfig config)</code>. The <code>FilterConfig</code> object can still be retrieved
-     * via {@link #getFilterConfig}.
+     * <code>GenericFilter.init(FilterConfig config)</code>. The <code>FilterConfig</code> object can still be retrieved via
+     * {@link #getFilterConfig}.
      * 
      * @exception ServletException if an exception occurs that interrupts the servlet's normal operation
      *

--- a/api/src/main/java/jakarta/servlet/GenericServlet.java
+++ b/api/src/main/java/jakarta/servlet/GenericServlet.java
@@ -71,8 +71,8 @@ public abstract class GenericServlet implements Servlet, ServletConfig, java.io.
     }
 
     /**
-     * Returns a <code>String</code> containing the value of the named initialization parameter, or <code>null</code> if
-     * the parameter does not exist. See {@link ServletConfig#getInitParameter}.
+     * Returns a <code>String</code> containing the value of the named initialization parameter, or <code>null</code> if the
+     * parameter does not exist. See {@link ServletConfig#getInitParameter}.
      *
      * <p>
      * This method is supplied for convenience. It gets the value of the named parameter from the servlet's
@@ -94,17 +94,17 @@ public abstract class GenericServlet implements Servlet, ServletConfig, java.io.
     }
 
     /**
-     * Returns the names of the servlet's initialization parameters as an <code>Enumeration</code> of
-     * <code>String</code> objects, or an empty <code>Enumeration</code> if the servlet has no initialization
-     * parameters. See {@link ServletConfig#getInitParameterNames}.
+     * Returns the names of the servlet's initialization parameters as an <code>Enumeration</code> of <code>String</code>
+     * objects, or an empty <code>Enumeration</code> if the servlet has no initialization parameters. See
+     * {@link ServletConfig#getInitParameterNames}.
      *
      * <p>
-     * This method is supplied for convenience. It gets the parameter names from the servlet's
-     * <code>ServletConfig</code> object.
+     * This method is supplied for convenience. It gets the parameter names from the servlet's <code>ServletConfig</code>
+     * object.
      *
      *
      * @return Enumeration an enumeration of <code>String</code> objects containing the names of the servlet's
-     *         initialization parameters
+     * initialization parameters
      */
     @Override
     public Enumeration<String> getInitParameterNames() {
@@ -131,12 +131,10 @@ public abstract class GenericServlet implements Servlet, ServletConfig, java.io.
      * {@link ServletConfig#getServletContext}.
      *
      * <p>
-     * This method is supplied for convenience. It gets the context from the servlet's <code>ServletConfig</code>
-     * object.
+     * This method is supplied for convenience. It gets the context from the servlet's <code>ServletConfig</code> object.
      *
      *
-     * @return ServletContext the <code>ServletContext</code> object passed to this servlet by the <code>init</code>
-     *         method
+     * @return ServletContext the <code>ServletContext</code> object passed to this servlet by the <code>init</code> method
      */
     @Override
     public ServletContext getServletContext() {
@@ -185,8 +183,8 @@ public abstract class GenericServlet implements Servlet, ServletConfig, java.io.
      *
      * <p>
      * Instead of overriding {@link #init(ServletConfig)}, simply override this method and it will be called by
-     * <code>GenericServlet.init(ServletConfig config)</code>. The <code>ServletConfig</code> object can still be
-     * retrieved via {@link #getServletConfig}.
+     * <code>GenericServlet.init(ServletConfig config)</code>. The <code>ServletConfig</code> object can still be retrieved
+     * via {@link #getServletConfig}.
      *
      * @exception ServletException if an exception occurs that interrupts the servlet's normal operation
      */
@@ -205,13 +203,13 @@ public abstract class GenericServlet implements Servlet, ServletConfig, java.io.
     }
 
     /**
-     * Writes an explanatory message and a stack trace for a given <code>Throwable</code> exception to the servlet log
-     * file, prepended by the servlet's name. See {@link ServletContext#log(String, Throwable)}.
+     * Writes an explanatory message and a stack trace for a given <code>Throwable</code> exception to the servlet log file,
+     * prepended by the servlet's name. See {@link ServletContext#log(String, Throwable)}.
      *
      *
      * @param message a <code>String</code> that describes the error or exception
      *
-     * @param t       the <code>java.lang.Throwable</code> error or exception
+     * @param t the <code>java.lang.Throwable</code> error or exception
      */
     public void log(String message, Throwable t) {
         getServletContext().log(getServletName() + ": " + message, t);
@@ -229,7 +227,7 @@ public abstract class GenericServlet implements Servlet, ServletConfig, java.io.
      *
      * @exception ServletException if an exception occurs that interferes with the servlet's normal operation occurred
      *
-     * @exception IOException      if an input or output exception occurs
+     * @exception IOException if an input or output exception occurs
      */
     @Override
     public abstract void service(ServletRequest req, ServletResponse res) throws ServletException, IOException;

--- a/api/src/main/java/jakarta/servlet/HttpConstraintElement.java
+++ b/api/src/main/java/jakarta/servlet/HttpConstraintElement.java
@@ -61,10 +61,10 @@ public class HttpConstraintElement {
     /**
      * Constructor to establish all of getEmptyRoleSemantic, getRolesAllowed, and getTransportGuarantee.
      *
-     * @param semantic  <tt>EmptyRoleSemantic.DENY</tt> or <tt>EmptyRoleSemantic.PERMIT</tt>
+     * @param semantic <tt>EmptyRoleSemantic.DENY</tt> or <tt>EmptyRoleSemantic.PERMIT</tt>
      * @param guarantee <tt>TransportGuarantee.NONE</tt> or <tt>TransportGuarantee.CONFIDENTIAL</tt>
      * @param roleNames the names of the roles that are to be allowed access, or missing if the semantic is
-     *                  <tt>EmptyRoleSemantic.DENY</tt>
+     * <tt>EmptyRoleSemantic.DENY</tt>
      */
     public HttpConstraintElement(EmptyRoleSemantic semantic, TransportGuarantee guarantee, String... roleNames) {
         if (semantic == EmptyRoleSemantic.DENY && roleNames.length > 0) {
@@ -79,11 +79,11 @@ public class HttpConstraintElement {
      * Gets the default authorization semantic.
      *
      * <p>
-     * This value is insignificant when <code>getRolesAllowed</code> returns a non-empty array, and should not be
-     * specified when a non-empty array is specified for <tt>getRolesAllowed</tt>.
+     * This value is insignificant when <code>getRolesAllowed</code> returns a non-empty array, and should not be specified
+     * when a non-empty array is specified for <tt>getRolesAllowed</tt>.
      *
      * @return the {@link EmptyRoleSemantic} to be applied when <code>getRolesAllowed</code> returns an empty (that is,
-     *         zero-length) array
+     * zero-length) array
      */
     public EmptyRoleSemantic getEmptyRoleSemantic() {
         return this.emptyRoleSemantic;
@@ -103,16 +103,15 @@ public class HttpConstraintElement {
      * Gets the names of the authorized roles.
      *
      * <p>
-     * Duplicate role names appearing in getRolesAllowed are insignificant and may be discarded. The String <tt>"*"</tt>
-     * has no special meaning as a role name (should it occur in getRolesAllowed).
+     * Duplicate role names appearing in getRolesAllowed are insignificant and may be discarded. The String <tt>"*"</tt> has
+     * no special meaning as a role name (should it occur in getRolesAllowed).
      *
      * @return a (possibly empty) array of role names. When the array is empty, its meaning depends on the value of
-     *         {@link #getEmptyRoleSemantic}. If its value is <tt>DENY</tt>, and <code>getRolesAllowed</code> returns an
-     *         empty array, access is to be denied independent of authentication state and identity. Conversely, if its
-     *         value is <code>PERMIT</code>, it indicates that access is to be allowed independent of authentication
-     *         state and identity. When the array contains the names of one or more roles, it indicates that access is
-     *         contingent on membership in at least one of the named roles (independent of the value of
-     *         {@link #getEmptyRoleSemantic}).
+     * {@link #getEmptyRoleSemantic}. If its value is <tt>DENY</tt>, and <code>getRolesAllowed</code> returns an empty
+     * array, access is to be denied independent of authentication state and identity. Conversely, if its value is
+     * <code>PERMIT</code>, it indicates that access is to be allowed independent of authentication state and identity. When
+     * the array contains the names of one or more roles, it indicates that access is contingent on membership in at least
+     * one of the named roles (independent of the value of {@link #getEmptyRoleSemantic}).
      */
     public String[] getRolesAllowed() {
         return copyStrings(this.rolesAllowed);

--- a/api/src/main/java/jakarta/servlet/HttpMethodConstraintElement.java
+++ b/api/src/main/java/jakarta/servlet/HttpMethodConstraintElement.java
@@ -31,8 +31,8 @@ public class HttpMethodConstraintElement extends HttpConstraintElement {
     /**
      * Constructs an instance with default {@link HttpConstraintElement} value.
      *
-     * @param methodName the name of an HTTP protocol method. The name must not be null, or the empty string, and must
-     *                   be a legitimate HTTP Method name as defined by RFC 2616
+     * @param methodName the name of an HTTP protocol method. The name must not be null, or the empty string, and must be a
+     * legitimate HTTP Method name as defined by RFC 2616
      */
     public HttpMethodConstraintElement(String methodName) {
         if (methodName == null || methodName.length() == 0) {
@@ -44,8 +44,8 @@ public class HttpMethodConstraintElement extends HttpConstraintElement {
     /**
      * Constructs an instance with specified {@link HttpConstraintElement} value.
      *
-     * @param methodName the name of an HTTP protocol method. The name must not be null, or the empty string, and must
-     *                   be a legitimate HTTP Method name as defined by RFC 2616
+     * @param methodName the name of an HTTP protocol method. The name must not be null, or the empty string, and must be a
+     * legitimate HTTP Method name as defined by RFC 2616
      *
      * @param constraint the HTTPconstraintElement value to assign to the named HTTP method
      */

--- a/api/src/main/java/jakarta/servlet/MultipartConfigElement.java
+++ b/api/src/main/java/jakarta/servlet/MultipartConfigElement.java
@@ -50,9 +50,9 @@ public class MultipartConfigElement {
     /**
      * Constructs an instance with all values specified.
      *
-     * @param location          the directory location where files will be stored
-     * @param maxFileSize       the maximum size allowed for uploaded files
-     * @param maxRequestSize    the maximum size allowed for multipart/form-data requests
+     * @param location the directory location where files will be stored
+     * @param maxFileSize the maximum size allowed for uploaded files
+     * @param maxRequestSize the maximum size allowed for multipart/form-data requests
      * @param fileSizeThreshold the size threshold after which files will be written to disk
      */
     public MultipartConfigElement(String location, long maxFileSize, long maxRequestSize, int fileSizeThreshold) {

--- a/api/src/main/java/jakarta/servlet/ReadListener.java
+++ b/api/src/main/java/jakarta/servlet/ReadListener.java
@@ -31,10 +31,10 @@ import java.util.EventListener;
 public interface ReadListener extends EventListener {
 
     /**
-     * When an instance of the <code>ReadListener</code> is registered with a {@link ServletInputStream}, this method
-     * will be invoked by the container the first time when it is possible to read data. Subsequently the container will
-     * invoke this method if and only if the {@link jakarta.servlet.ServletInputStream#isReady()} method has been called
-     * and has returned a value of <code>false</code> <em>and</em> data has subsequently become available to read.
+     * When an instance of the <code>ReadListener</code> is registered with a {@link ServletInputStream}, this method will
+     * be invoked by the container the first time when it is possible to read data. Subsequently the container will invoke
+     * this method if and only if the {@link jakarta.servlet.ServletInputStream#isReady()} method has been called and has
+     * returned a value of <code>false</code> <em>and</em> data has subsequently become available to read.
      *
      * @throws IOException if an I/O related error has occurred during processing
      */

--- a/api/src/main/java/jakarta/servlet/Registration.java
+++ b/api/src/main/java/jakarta/servlet/Registration.java
@@ -47,23 +47,23 @@ public interface Registration {
     /**
      * Gets the fully qualified class name of the Servlet or Filter that is represented by this Registration.
      *
-     * @return the fully qualified class name of the Servlet or Filter that is represented by this Registration, or null
-     *         if this Registration is preliminary
+     * @return the fully qualified class name of the Servlet or Filter that is represented by this Registration, or null if
+     * this Registration is preliminary
      */
     public String getClassName();
 
     /**
-     * Sets the initialization parameter with the given name and value on the Servlet or Filter that is represented by
-     * this Registration.
+     * Sets the initialization parameter with the given name and value on the Servlet or Filter that is represented by this
+     * Registration.
      *
-     * @param name  the initialization parameter name
+     * @param name the initialization parameter name
      * @param value the initialization parameter value
      *
      * @return true if the update was successful, i.e., an initialization parameter with the given name did not already
-     *         exist for the Servlet or Filter represented by this Registration, and false otherwise
+     * exist for the Servlet or Filter represented by this Registration, and false otherwise
      *
-     * @throws IllegalStateException    if the ServletContext from which this Registration was obtained has already been
-     *                                  initialized
+     * @throws IllegalStateException if the ServletContext from which this Registration was obtained has already been
+     * initialized
      * @throws IllegalArgumentException if the given name or value is <tt>null</tt>
      */
     public boolean setInitParameter(String name, String value);
@@ -75,7 +75,7 @@ public interface Registration {
      * @param name the name of the initialization parameter whose value is requested
      *
      * @return the value of the initialization parameter with the given name, or <tt>null</tt> if no initialization
-     *         parameter with the given name exists
+     * parameter with the given name exists
      */
     public String getInitParameter(String name);
 
@@ -84,33 +84,33 @@ public interface Registration {
      *
      * <p>
      * The given map of initialization parameters is processed <i>by-value</i>, i.e., for each initialization parameter
-     * contained in the map, this method calls {@link #setInitParameter(String,String)}. If that method would return
-     * false for any of the initialization parameters in the given map, no updates will be performed, and false will be
-     * returned. Likewise, if the map contains an initialization parameter with a <tt>null</tt> name or value, no
-     * updates will be performed, and an IllegalArgumentException will be thrown.
+     * contained in the map, this method calls {@link #setInitParameter(String,String)}. If that method would return false
+     * for any of the initialization parameters in the given map, no updates will be performed, and false will be returned.
+     * Likewise, if the map contains an initialization parameter with a <tt>null</tt> name or value, no updates will be
+     * performed, and an IllegalArgumentException will be thrown.
      *
      * <p>
-     * The returned set is not backed by the {@code Registration} object, so changes in the returned set are not
-     * reflected in the {@code Registration} object, and vice-versa.
+     * The returned set is not backed by the {@code Registration} object, so changes in the returned set are not reflected
+     * in the {@code Registration} object, and vice-versa.
      * </p>
      *
      * @param initParameters the initialization parameters
      *
      * @return the (possibly empty) Set of initialization parameter names that are in conflict
      *
-     * @throws IllegalStateException    if the ServletContext from which this Registration was obtained has already been
-     *                                  initialized
-     * @throws IllegalArgumentException if the given map contains an initialization parameter with a <tt>null</tt> name
-     *                                  or value
+     * @throws IllegalStateException if the ServletContext from which this Registration was obtained has already been
+     * initialized
+     * @throws IllegalArgumentException if the given map contains an initialization parameter with a <tt>null</tt> name or
+     * value
      */
     public Set<String> setInitParameters(Map<String, String> initParameters);
 
     /**
-     * Gets an immutable (and possibly empty) Map containing the currently available initialization parameters that will
-     * be used to initialize the Servlet or Filter represented by this Registration object.
+     * Gets an immutable (and possibly empty) Map containing the currently available initialization parameters that will be
+     * used to initialize the Servlet or Filter represented by this Registration object.
      *
-     * @return Map containing the currently available initialization parameters that will be used to initialize the
-     *         Servlet or Filter represented by this Registration object
+     * @return Map containing the currently available initialization parameters that will be used to initialize the Servlet
+     * or Filter represented by this Registration object
      */
     public Map<String, String> getInitParameters();
 
@@ -121,8 +121,8 @@ public interface Registration {
     interface Dynamic extends Registration {
 
         /**
-         * Configures the Servlet or Filter represented by this dynamic Registration as supporting asynchronous
-         * operations or not.
+         * Configures the Servlet or Filter represented by this dynamic Registration as supporting asynchronous operations or
+         * not.
          *
          * <p>
          * By default, servlet and filters do not support asynchronous operations.
@@ -130,11 +130,11 @@ public interface Registration {
          * <p>
          * A call to this method overrides any previous setting.
          *
-         * @param isAsyncSupported true if the Servlet or Filter represented by this dynamic Registration supports
-         *                         asynchronous operations, false otherwise
+         * @param isAsyncSupported true if the Servlet or Filter represented by this dynamic Registration supports asynchronous
+         * operations, false otherwise
          *
-         * @throws IllegalStateException if the ServletContext from which this dynamic Registration was obtained has
-         *                               already been initialized
+         * @throws IllegalStateException if the ServletContext from which this dynamic Registration was obtained has already
+         * been initialized
          */
         public void setAsyncSupported(boolean isAsyncSupported);
     }

--- a/api/src/main/java/jakarta/servlet/RequestDispatcher.java
+++ b/api/src/main/java/jakarta/servlet/RequestDispatcher.java
@@ -94,8 +94,8 @@ public interface RequestDispatcher {
     static final String INCLUDE_PATH_INFO = "jakarta.servlet.include.path_info";
 
     /**
-     * The name of the request attribute under which the {@link jakarta.servlet.http.HttpServletMapping} of the target of
-     * an {@link #include(ServletRequest,ServletResponse) include} is stored
+     * The name of the request attribute under which the {@link jakarta.servlet.http.HttpServletMapping} of the target of an
+     * {@link #include(ServletRequest,ServletResponse) include} is stored
      */
     static final String INCLUDE_MAPPING = "jakarta.servlet.include.mapping";
 
@@ -117,8 +117,7 @@ public interface RequestDispatcher {
     public static final String ERROR_EXCEPTION = "jakarta.servlet.error.exception";
 
     /**
-     * The name of the request attribute under which the type of the exception object is propagated during an error
-     * dispatch
+     * The name of the request attribute under which the type of the exception object is propagated during an error dispatch
      */
     public static final String ERROR_EXCEPTION_TYPE = "jakarta.servlet.error.exception_type";
 
@@ -128,8 +127,8 @@ public interface RequestDispatcher {
     public static final String ERROR_MESSAGE = "jakarta.servlet.error.message";
 
     /**
-     * The name of the request attribute under which the request URI whose processing caused the error is propagated
-     * during an error dispatch
+     * The name of the request attribute under which the request URI whose processing caused the error is propagated during
+     * an error dispatch
      */
     public static final String ERROR_REQUEST_URI = "jakarta.servlet.error.request_uri";
 
@@ -145,9 +144,8 @@ public interface RequestDispatcher {
     public static final String ERROR_STATUS_CODE = "jakarta.servlet.error.status_code";
 
     /**
-     * Forwards a request from a servlet to another resource (servlet, JSP file, or HTML file) on the server. This
-     * method allows one servlet to do preliminary processing of a request and another resource to generate the
-     * response.
+     * Forwards a request from a servlet to another resource (servlet, JSP file, or HTML file) on the server. This method
+     * allows one servlet to do preliminary processing of a request and another resource to generate the response.
      *
      * <p>
      * For a <code>RequestDispatcher</code> obtained via <code>getRequestDispatcher()</code>, the
@@ -161,20 +159,20 @@ public interface RequestDispatcher {
      * forward.
      *
      * <p>
-     * The request and response parameters must be either the same objects as were passed to the calling servlet's
-     * service method or be subclasses of the {@link ServletRequestWrapper} or {@link ServletResponseWrapper} classes
-     * that wrap them.
+     * The request and response parameters must be either the same objects as were passed to the calling servlet's service
+     * method or be subclasses of the {@link ServletRequestWrapper} or {@link ServletResponseWrapper} classes that wrap
+     * them.
      *
      * <p>
      * This method sets the dispatcher type of the given request to <code>DispatcherType.FORWARD</code>.
      *
-     * @param request  a {@link ServletRequest} object that represents the request the client makes of the servlet
+     * @param request a {@link ServletRequest} object that represents the request the client makes of the servlet
      *
      * @param response a {@link ServletResponse} object that represents the response the servlet returns to the client
      *
-     * @throws ServletException      if the target resource throws this exception
+     * @throws ServletException if the target resource throws this exception
      *
-     * @throws IOException           if the target resource throws this exception
+     * @throws IOException if the target resource throws this exception
      *
      * @throws IllegalStateException if the response was already committed
      *
@@ -184,28 +182,28 @@ public interface RequestDispatcher {
 
     /**
      *
-     * Includes the content of a resource (servlet, JSP page, HTML file) in the response. In essence, this method
-     * enables programmatic server-side includes.
+     * Includes the content of a resource (servlet, JSP page, HTML file) in the response. In essence, this method enables
+     * programmatic server-side includes.
      *
      * <p>
      * The {@link ServletResponse} object has its path elements and parameters remain unchanged from the caller's. The
      * included servlet cannot change the response status code or set headers; any attempt to make a change is ignored.
      *
      * <p>
-     * The request and response parameters must be either the same objects as were passed to the calling servlet's
-     * service method or be subclasses of the {@link ServletRequestWrapper} or {@link ServletResponseWrapper} classes
-     * that wrap them.
+     * The request and response parameters must be either the same objects as were passed to the calling servlet's service
+     * method or be subclasses of the {@link ServletRequestWrapper} or {@link ServletResponseWrapper} classes that wrap
+     * them.
      *
      * <p>
      * This method sets the dispatcher type of the given request to <code>DispatcherType.INCLUDE</code>.
      *
-     * @param request  a {@link ServletRequest} object that contains the client's request
+     * @param request a {@link ServletRequest} object that contains the client's request
      *
      * @param response a {@link ServletResponse} object that contains the servlet's response
      *
      * @throws ServletException if the included resource throws this exception
      *
-     * @throws IOException      if the included resource throws this exception
+     * @throws IOException if the included resource throws this exception
      *
      * @see ServletRequest#getDispatcherType
      */

--- a/api/src/main/java/jakarta/servlet/Servlet.java
+++ b/api/src/main/java/jakarta/servlet/Servlet.java
@@ -70,7 +70,7 @@ public interface Servlet {
      *
      *
      * @param config a <code>ServletConfig</code> object containing the servlet's configuration and initialization
-     *               parameters
+     * parameters
      *
      * @exception ServletException if an exception has occurred that interferes with the servlet's normal operation
      *
@@ -82,8 +82,8 @@ public interface Servlet {
 
     /**
      *
-     * Returns a {@link ServletConfig} object, which contains initialization and startup parameters for this servlet.
-     * The <code>ServletConfig</code> object returned is the one passed to the <code>init</code> method.
+     * Returns a {@link ServletConfig} object, which contains initialization and startup parameters for this servlet. The
+     * <code>ServletConfig</code> object returned is the one passed to the <code>init</code> method.
      *
      * <p>
      * Implementations of this interface are responsible for storing the <code>ServletConfig</code> object so that this
@@ -117,7 +117,7 @@ public interface Servlet {
      *
      * @exception ServletException if an exception occurs that interferes with the servlet's normal operation
      *
-     * @exception IOException      if an input or output exception occurs
+     * @exception IOException if an input or output exception occurs
      *
      */
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException;
@@ -135,15 +135,14 @@ public interface Servlet {
 
     /**
      *
-     * Called by the servlet container to indicate to a servlet that the servlet is being taken out of service. This
-     * method is only called once all threads within the servlet's <code>service</code> method have exited or after a
-     * timeout period has passed. After the servlet container calls this method, it will not call the
-     * <code>service</code> method again on this servlet.
+     * Called by the servlet container to indicate to a servlet that the servlet is being taken out of service. This method
+     * is only called once all threads within the servlet's <code>service</code> method have exited or after a timeout
+     * period has passed. After the servlet container calls this method, it will not call the <code>service</code> method
+     * again on this servlet.
      *
      * <p>
-     * This method gives the servlet an opportunity to clean up any resources that are being held (for example, memory,
-     * file handles, threads) and make sure that any persistent state is synchronized with the servlet's current state
-     * in memory.
+     * This method gives the servlet an opportunity to clean up any resources that are being held (for example, memory, file
+     * handles, threads) and make sure that any persistent state is synchronized with the servlet's current state in memory.
      *
      */
     public void destroy();

--- a/api/src/main/java/jakarta/servlet/ServletConfig.java
+++ b/api/src/main/java/jakarta/servlet/ServletConfig.java
@@ -26,8 +26,8 @@ import java.util.Enumeration;
 public interface ServletConfig {
 
     /**
-     * Returns the name of this servlet instance. The name may be provided via server administration, assigned in the
-     * web application deployment descriptor, or for an unregistered (and thus unnamed) servlet instance it will be the
+     * Returns the name of this servlet instance. The name may be provided via server administration, assigned in the web
+     * application deployment descriptor, or for an unregistered (and thus unnamed) servlet instance it will be the
      * servlet's class name.
      *
      * @return the name of the servlet instance
@@ -49,17 +49,16 @@ public interface ServletConfig {
      * @param name the name of the initialization parameter whose value to get
      *
      * @return a <code>String</code> containing the value of the initialization parameter, or <code>null</code> if the
-     *         initialization parameter does not exist
+     * initialization parameter does not exist
      */
     public String getInitParameter(String name);
 
     /**
-     * Returns the names of the servlet's initialization parameters as an <code>Enumeration</code> of
-     * <code>String</code> objects, or an empty <code>Enumeration</code> if the servlet has no initialization
-     * parameters.
+     * Returns the names of the servlet's initialization parameters as an <code>Enumeration</code> of <code>String</code>
+     * objects, or an empty <code>Enumeration</code> if the servlet has no initialization parameters.
      *
      * @return an <code>Enumeration</code> of <code>String</code> objects containing the names of the servlet's
-     *         initialization parameters
+     * initialization parameters
      */
     public Enumeration<String> getInitParameterNames();
 

--- a/api/src/main/java/jakarta/servlet/ServletContainerInitializer.java
+++ b/api/src/main/java/jakarta/servlet/ServletContainerInitializer.java
@@ -59,19 +59,18 @@ public interface ServletContainerInitializer {
      * <tt>ServletContext</tt>.
      *
      * <p>
-     * If this <tt>ServletContainerInitializer</tt> is bundled in a JAR file inside the <tt>WEB-INF/lib</tt> directory
-     * of an application, its <tt>onStartup</tt> method will be invoked only once during the startup of the bundling
-     * application. If this <tt>ServletContainerInitializer</tt> is bundled inside a JAR file outside of any
-     * <tt>WEB-INF/lib</tt> directory, but still discoverable as described above, its <tt>onStartup</tt> method will be
-     * invoked every time an application is started.
+     * If this <tt>ServletContainerInitializer</tt> is bundled in a JAR file inside the <tt>WEB-INF/lib</tt> directory of an
+     * application, its <tt>onStartup</tt> method will be invoked only once during the startup of the bundling application.
+     * If this <tt>ServletContainerInitializer</tt> is bundled inside a JAR file outside of any <tt>WEB-INF/lib</tt>
+     * directory, but still discoverable as described above, its <tt>onStartup</tt> method will be invoked every time an
+     * application is started.
      *
-     * @param c   the Set of application classes that extend, implement, or have been annotated with the class types
-     *            specified by the {@link jakarta.servlet.annotation.HandlesTypes HandlesTypes} annotation, or
-     *            <tt>null</tt> if there are no matches, or this <tt>ServletContainerInitializer</tt> has not been
-     *            annotated with <tt>HandlesTypes</tt>
+     * @param c the Set of application classes that extend, implement, or have been annotated with the class types specified
+     * by the {@link jakarta.servlet.annotation.HandlesTypes HandlesTypes} annotation, or <tt>null</tt> if there are no
+     * matches, or this <tt>ServletContainerInitializer</tt> has not been annotated with <tt>HandlesTypes</tt>
      *
      * @param ctx the <tt>ServletContext</tt> of the web application that is being started and in which the classes
-     *            contained in <tt>c</tt> were found
+     * contained in <tt>c</tt> were found
      *
      * @throws ServletException if an error has occurred
      */

--- a/api/src/main/java/jakarta/servlet/ServletContext.java
+++ b/api/src/main/java/jakarta/servlet/ServletContext.java
@@ -18,6 +18,7 @@
 
 package jakarta.servlet;
 
+import jakarta.servlet.descriptor.JspConfigDescriptor;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -25,7 +26,6 @@ import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Map;
 import java.util.Set;
-import jakarta.servlet.descriptor.JspConfigDescriptor;
 
 /**
  * Defines a set of methods that a servlet uses to communicate with its servlet container, for example, to get the MIME
@@ -73,14 +73,14 @@ public interface ServletContext {
      * <p>
      * The context path is the portion of the request URI that is used to select the context of the request. The context
      * path always comes first in a request URI. If this context is the "root" context rooted at the base of the Web
-     * server's URL name space, this path will be an empty string. Otherwise, if the context is not rooted at the root
-     * of the server's name space, the path starts with a / character but does not end with a / character.
+     * server's URL name space, this path will be an empty string. Otherwise, if the context is not rooted at the root of
+     * the server's name space, the path starts with a / character but does not end with a / character.
      *
      * <p>
      * It is possible that a servlet container may match a context by more than one context path. In such cases the
      * {@link jakarta.servlet.http.HttpServletRequest#getContextPath()} will return the actual context path used by the
-     * request and it may differ from the path returned by this method. The context path returned by this method should
-     * be considered as the prime or preferred context path of the application.
+     * request and it may differ from the path returned by this method. The context path returned by this method should be
+     * considered as the prime or preferred context path of the application.
      *
      * @return The context path of the web application, or "" for the root context
      *
@@ -96,73 +96,71 @@ public interface ServletContext {
      * <p>
      * This method allows servlets to gain access to the context for various parts of the server, and as needed obtain
      * {@link RequestDispatcher} objects from the context. The given path must be begin with <tt>/</tt>, is interpreted
-     * relative to the server's document root and is matched against the context roots of other web applications hosted
-     * on this container.
+     * relative to the server's document root and is matched against the context roots of other web applications hosted on
+     * this container.
      *
      * <p>
      * In a security conscious environment, the servlet container may return <code>null</code> for a given URL.
      *
      * @param uripath a <code>String</code> specifying the context path of another web application in the container.
-     * @return the <code>ServletContext</code> object that corresponds to the named URL, or null if either none exists
-     *         or the container wishes to restrict this access.
+     * @return the <code>ServletContext</code> object that corresponds to the named URL, or null if either none exists or
+     * the container wishes to restrict this access.
      *
      * @see RequestDispatcher
      */
     public ServletContext getContext(String uripath);
 
     /**
-     * Returns the major version of Jakarta Servlet that this container supports. All implementations that
-     * comply with Version 4.0 must have this method return the integer 4.
+     * Returns the major version of Jakarta Servlet that this container supports. All implementations that comply with
+     * Version 4.0 must have this method return the integer 4.
      *
      * @return 4
      */
     public int getMajorVersion();
 
     /**
-     * Returns the minor version of Jakarta Servlet that this container supports. All implementations that
-     * comply with Version 4.0 must have this method return the integer 0.
+     * Returns the minor version of Jakarta Servlet that this container supports. All implementations that comply with
+     * Version 4.0 must have this method return the integer 0.
      *
      * @return 0
      */
     public int getMinorVersion();
 
     /**
-     * Gets the major version of the Servlet specification that the application represented by this ServletContext is
-     * based on.
+     * Gets the major version of the Servlet specification that the application represented by this ServletContext is based
+     * on.
      *
      * <p>
      * The value returned may be different from {@link #getMajorVersion}, which returns the major version of the Servlet
      * specification supported by the Servlet container.
      *
      * @return the major version of the Servlet specification that the application represented by this ServletContext is
-     *         based on
+     * based on
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
     public int getEffectiveMajorVersion();
 
     /**
-     * Gets the minor version of the Servlet specification that the application represented by this ServletContext is
-     * based on.
+     * Gets the minor version of the Servlet specification that the application represented by this ServletContext is based
+     * on.
      *
      * <p>
      * The value returned may be different from {@link #getMinorVersion}, which returns the minor version of the Servlet
      * specification supported by the Servlet container.
      *
      * @return the minor version of the Servlet specification that the application represented by this ServletContext is
-     *         based on
+     * based on
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -188,12 +186,12 @@ public interface ServletContext {
      *
      * <p>
      * The returned paths are all relative to the root of the web application, or relative to the
-     * <tt>/META-INF/resources</tt> directory of a JAR file inside the web application's <tt>/WEB-INF/lib</tt>
-     * directory, and have a leading <tt>/</tt>.
+     * <tt>/META-INF/resources</tt> directory of a JAR file inside the web application's <tt>/WEB-INF/lib</tt> directory,
+     * and have a leading <tt>/</tt>.
      *
      * <p>
-     * The returned set is not backed by the {@code ServletContext} object, so changes in the returned set are not
-     * reflected in the {@code ServletContext} object, and vice-versa.
+     * The returned set is not backed by the {@code ServletContext} object, so changes in the returned set are not reflected
+     * in the {@code ServletContext} object, and vice-versa.
      * </p>
      *
      * <p>
@@ -213,13 +211,13 @@ public interface ServletContext {
      * }
      * </pre>
      *
-     * <tt>getResourcePaths("/")</tt> would return <tt>{"/welcome.html", "/catalog/", "/customer/", "/WEB-INF/"}</tt>,
-     * and <tt>getResourcePaths("/catalog/")</tt> would return <tt>{"/catalog/index.html", "/catalog/products.html",
+     * <tt>getResourcePaths("/")</tt> would return <tt>{"/welcome.html", "/catalog/", "/customer/", "/WEB-INF/"}</tt>, and
+     * <tt>getResourcePaths("/catalog/")</tt> would return <tt>{"/catalog/index.html", "/catalog/products.html",
      * "/catalog/offers/", "/catalog/moreOffers/"}</tt>.
      *
      * @param path the partial path used to match the resources, which must start with a <tt>/</tt>
-     * @return a Set containing the directory listing, or null if there are no resources in the web application whose
-     *         path begins with the supplied path.
+     * @return a Set containing the directory listing, or null if there are no resources in the web application whose path
+     * begins with the supplied path.
      *
      * @since Servlet 2.3
      */
@@ -229,19 +227,19 @@ public interface ServletContext {
      * Returns a URL to the resource that is mapped to the given path.
      *
      * <p>
-     * The path must begin with a <tt>/</tt> and is interpreted as relative to the current context root, or relative to
-     * the <tt>/META-INF/resources</tt> directory of a JAR file inside the web application's <tt>/WEB-INF/lib</tt>
-     * directory. This method will first search the document root of the web application for the requested resource,
-     * before searching any of the JAR files inside <tt>/WEB-INF/lib</tt>. The order in which the JAR files inside
-     * <tt>/WEB-INF/lib</tt> are searched is undefined.
+     * The path must begin with a <tt>/</tt> and is interpreted as relative to the current context root, or relative to the
+     * <tt>/META-INF/resources</tt> directory of a JAR file inside the web application's <tt>/WEB-INF/lib</tt> directory.
+     * This method will first search the document root of the web application for the requested resource, before searching
+     * any of the JAR files inside <tt>/WEB-INF/lib</tt>. The order in which the JAR files inside <tt>/WEB-INF/lib</tt> are
+     * searched is undefined.
      *
      * <p>
-     * This method allows the servlet container to make a resource available to servlets from any source. Resources can
-     * be located on a local or remote file system, in a database, or in a <code>.war</code> file.
+     * This method allows the servlet container to make a resource available to servlets from any source. Resources can be
+     * located on a local or remote file system, in a database, or in a <code>.war</code> file.
      *
      * <p>
-     * The servlet container must implement the URL handlers and <code>URLConnection</code> objects that are necessary
-     * to access the resource.
+     * The servlet container must implement the URL handlers and <code>URLConnection</code> objects that are necessary to
+     * access the resource.
      *
      * <p>
      * This method returns <code>null</code> if no resource is mapped to the pathname.
@@ -254,13 +252,13 @@ public interface ServletContext {
      * source code. Use a <code>RequestDispatcher</code> instead to include results of an execution.
      *
      * <p>
-     * This method has a different purpose than <code>java.lang.Class.getResource</code>, which looks up resources based
-     * on a class loader. This method does not use class loaders.
+     * This method has a different purpose than <code>java.lang.Class.getResource</code>, which looks up resources based on
+     * a class loader. This method does not use class loaders.
      *
      * <p>
      * This method bypasses both implicit (no direct access to WEB-INF or META-INF) and explicit (defined by the web
-     * application) security constraints. Care should be taken both when constructing the path (e.g. avoid unsanitized
-     * user provided data) and when using the result not to create a security vulnerability in the application.
+     * application) security constraints. Care should be taken both when constructing the path (e.g. avoid unsanitized user
+     * provided data) and when using the result not to create a security vulnerability in the application.
      *
      * @param path a <code>String</code> specifying the path to the resource
      *
@@ -274,41 +272,41 @@ public interface ServletContext {
      * Returns the resource located at the named path as an <code>InputStream</code> object.
      *
      * <p>
-     * The data in the <code>InputStream</code> can be of any type or length. The path must be specified according to
-     * the rules given in <code>getResource</code>. This method returns <code>null</code> if no resource exists at the
-     * specified path.
+     * The data in the <code>InputStream</code> can be of any type or length. The path must be specified according to the
+     * rules given in <code>getResource</code>. This method returns <code>null</code> if no resource exists at the specified
+     * path.
      *
      * <p>
      * Meta-information such as content length and content type that is available via <code>getResource</code> method is
      * lost when using this method.
      *
      * <p>
-     * The servlet container must implement the URL handlers and <code>URLConnection</code> objects necessary to access
-     * the resource.
+     * The servlet container must implement the URL handlers and <code>URLConnection</code> objects necessary to access the
+     * resource.
      *
      * <p>
      * This method is different from <code>java.lang.Class.getResourceAsStream</code>, which uses a class loader. This
-     * method allows servlet containers to make a resource available to a servlet from any location, without using a
-     * class loader.
+     * method allows servlet containers to make a resource available to a servlet from any location, without using a class
+     * loader.
      *
      * <p>
      * This method bypasses both implicit (no direct access to WEB-INF or META-INF) and explicit (defined by the web
-     * application) security constraints. Care should be taken both when constructing the path (e.g. avoid unsanitized
-     * user provided data) and when using the result not to create a security vulnerability in the application.
+     * application) security constraints. Care should be taken both when constructing the path (e.g. avoid unsanitized user
+     * provided data) and when using the result not to create a security vulnerability in the application.
      *
      *
      * @param path a <code>String</code> specifying the path to the resource
      *
      * @return the <code>InputStream</code> returned to the servlet, or <code>null</code> if no resource exists at the
-     *         specified path
+     * specified path
      */
     public InputStream getResourceAsStream(String path);
 
     /**
      *
      * Returns a {@link RequestDispatcher} object that acts as a wrapper for the resource located at the given path. A
-     * <code>RequestDispatcher</code> object can be used to forward a request to the resource or to include the resource
-     * in a response. The resource can be dynamic or static.
+     * <code>RequestDispatcher</code> object can be used to forward a request to the resource or to include the resource in
+     * a response. The resource can be dynamic or static.
      *
      * <p>
      * The pathname must begin with a <tt>/</tt> and is interpreted as relative to the current context root. Use
@@ -321,7 +319,7 @@ public interface ServletContext {
      * @param path a <code>String</code> specifying the pathname to the resource
      *
      * @return a <code>RequestDispatcher</code> object that acts as a wrapper for the resource at the specified path, or
-     *         <code>null</code> if the <code>ServletContext</code> cannot return a <code>RequestDispatcher</code>
+     * <code>null</code> if the <code>ServletContext</code> cannot return a <code>RequestDispatcher</code>
      *
      * @see RequestDispatcher
      * @see ServletContext#getContext
@@ -341,8 +339,8 @@ public interface ServletContext {
      *
      * @param name a <code>String</code> specifying the name of a servlet to wrap
      *
-     * @return a <code>RequestDispatcher</code> object that acts as a wrapper for the named servlet, or
-     *         <code>null</code> if the <code>ServletContext</code> cannot return a <code>RequestDispatcher</code>
+     * @return a <code>RequestDispatcher</code> object that acts as a wrapper for the named servlet, or <code>null</code> if
+     * the <code>ServletContext</code> cannot return a <code>RequestDispatcher</code>
      *
      * @see RequestDispatcher
      * @see ServletContext#getContext
@@ -353,14 +351,14 @@ public interface ServletContext {
     /**
      * @deprecated As of Java Servlet API 2.1, with no direct replacement.
      *
-     *             <p>
-     *             This method was originally defined to retrieve a servlet from a <code>ServletContext</code>. In this
-     *             version, this method always returns <code>null</code> and remains only to preserve binary
-     *             compatibility. This method will be permanently removed in a future version of Jakarta Servlets.
+     * <p>
+     * This method was originally defined to retrieve a servlet from a <code>ServletContext</code>. In this version, this
+     * method always returns <code>null</code> and remains only to preserve binary compatibility. This method will be
+     * permanently removed in a future version of Jakarta Servlets.
      *
-     *             <p>
-     *             In lieu of this method, servlets can share information using the <code>ServletContext</code> class
-     *             and can perform shared business logic by invoking methods on common non-servlet classes.
+     * <p>
+     * In lieu of this method, servlets can share information using the <code>ServletContext</code> class and can perform
+     * shared business logic by invoking methods on common non-servlet classes.
      *
      * @param name the servlet name
      * @return the {@code jakarta.servlet.Servlet Servlet} with the given name
@@ -372,11 +370,10 @@ public interface ServletContext {
     /**
      * @deprecated As of Java Servlet API 2.0, with no replacement.
      *
-     *             <p>
-     *             This method was originally defined to return an <code>Enumeration</code> of all the servlets known to
-     *             this servlet context. In this version, this method always returns an empty enumeration and remains
-     *             only to preserve binary compatibility. This method will be permanently removed in a future version of
-     *             Jakarta Servlets.
+     * <p>
+     * This method was originally defined to return an <code>Enumeration</code> of all the servlets known to this servlet
+     * context. In this version, this method always returns an empty enumeration and remains only to preserve binary
+     * compatibility. This method will be permanently removed in a future version of Jakarta Servlets.
      *
      * @return an <code>Enumeration</code> of {@code jakarta.servlet.Servlet Servlet}
      */
@@ -386,11 +383,10 @@ public interface ServletContext {
     /**
      * @deprecated As of Java Servlet API 2.1, with no replacement.
      *
-     *             <p>
-     *             This method was originally defined to return an <code>Enumeration</code> of all the servlet names
-     *             known to this context. In this version, this method always returns an empty <code>Enumeration</code>
-     *             and remains only to preserve binary compatibility. This method will be permanently removed in a
-     *             future version of Jakarta Servlets.
+     * <p>
+     * This method was originally defined to return an <code>Enumeration</code> of all the servlet names known to this
+     * context. In this version, this method always returns an empty <code>Enumeration</code> and remains only to preserve
+     * binary compatibility. This method will be permanently removed in a future version of Jakarta Servlets.
      *
      * @return an <code>Enumeration</code> of {@code jakarta.servlet.Servlet Servlet} names
      */
@@ -399,8 +395,8 @@ public interface ServletContext {
 
     /**
      *
-     * Writes the specified message to a servlet log file, usually an event log. The name and type of the servlet log
-     * file is specific to the servlet container.
+     * Writes the specified message to a servlet log file, usually an event log. The name and type of the servlet log file
+     * is specific to the servlet container.
      *
      * @param msg a <code>String</code> specifying the message to be written to the log file
      */
@@ -409,21 +405,21 @@ public interface ServletContext {
     /**
      * @deprecated As of Java Servlet API 2.1, use {@link #log(String message, Throwable throwable)} instead.
      *
-     *             <p>
-     *             This method was originally defined to write an exception's stack trace and an explanatory error
-     *             message to the servlet log file.
+     * <p>
+     * This method was originally defined to write an exception's stack trace and an explanatory error message to the
+     * servlet log file.
      *
      * @param exception the <code>Exception</code> error
-     * @param msg       a <code>String</code> that describes the exception
+     * @param msg a <code>String</code> that describes the exception
      */
     @Deprecated
     public void log(Exception exception, String msg);
 
     /**
-     * Writes an explanatory message and a stack trace for a given <code>Throwable</code> exception to the servlet log
-     * file. The name and type of the servlet log file is specific to the servlet container, usually an event log.
+     * Writes an explanatory message and a stack trace for a given <code>Throwable</code> exception to the servlet log file.
+     * The name and type of the servlet log file is specific to the servlet container, usually an event log.
      *
-     * @param message   a <code>String</code> that describes the error or exception
+     * @param message a <code>String</code> that describes the error or exception
      *
      * @param throwable the <code>Throwable</code> error or exception
      */
@@ -433,8 +429,8 @@ public interface ServletContext {
      * Gets the <i>real</i> path corresponding to the given <i>virtual</i> path.
      *
      * <p>
-     * For example, if <tt>path</tt> is equal to <tt>/index.html</tt>, this method will return the absolute file path on
-     * the server's filesystem to which a request of the form
+     * For example, if <tt>path</tt> is equal to <tt>/index.html</tt>, this method will return the absolute file path on the
+     * server's filesystem to which a request of the form
      * <tt>http://&lt;host&gt;:&lt;port&gt;/&lt;contextPath&gt;/index.html</tt> would be mapped, where
      * <tt>&lt;contextPath&gt;</tt> corresponds to the context path of this ServletContext.
      *
@@ -444,12 +440,12 @@ public interface ServletContext {
      *
      * <p>
      * Resources inside the <tt>/META-INF/resources</tt> directories of JAR files bundled in the application's
-     * <tt>/WEB-INF/lib</tt> directory must be considered only if the container has unpacked them from their containing
-     * JAR file, in which case the path to the unpacked location must be returned.
+     * <tt>/WEB-INF/lib</tt> directory must be considered only if the container has unpacked them from their containing JAR
+     * file, in which case the path to the unpacked location must be returned.
      *
      * <p>
-     * This method returns <code>null</code> if the servlet container is unable to translate the given <i>virtual</i>
-     * path to a <i>real</i> path.
+     * This method returns <code>null</code> if the servlet container is unable to translate the given <i>virtual</i> path
+     * to a <i>real</i> path.
      *
      * @param path the <i>virtual</i> path to be translated to a <i>real</i> path
      *
@@ -483,8 +479,8 @@ public interface ServletContext {
      *
      * @param name a <code>String</code> containing the name of the parameter whose value is requested
      *
-     * @return a <code>String</code> containing the value of the context's initialization parameter, or
-     *         <code>null</code> if the context's initialization parameter does not exist.
+     * @return a <code>String</code> containing the value of the context's initialization parameter, or <code>null</code> if
+     * the context's initialization parameter does not exist.
      *
      * @throws NullPointerException if the argument {@code name} is {@code null}
      *
@@ -493,12 +489,11 @@ public interface ServletContext {
     public String getInitParameter(String name);
 
     /**
-     * Returns the names of the context's initialization parameters as an <code>Enumeration</code> of
-     * <code>String</code> objects, or an empty <code>Enumeration</code> if the context has no initialization
-     * parameters.
+     * Returns the names of the context's initialization parameters as an <code>Enumeration</code> of <code>String</code>
+     * objects, or an empty <code>Enumeration</code> if the context has no initialization parameters.
      *
      * @return an <code>Enumeration</code> of <code>String</code> objects containing the names of the context's
-     *         initialization parameters
+     * initialization parameters
      *
      * @see ServletConfig#getInitParameter
      */
@@ -507,47 +502,46 @@ public interface ServletContext {
     /**
      * Sets the context initialization parameter with the given name and value on this ServletContext.
      *
-     * @param name  the name of the context initialization parameter to set
+     * @param name the name of the context initialization parameter to set
      * @param value the value of the context initialization parameter to set
      *
      * @return true if the context initialization parameter with the given name and value was set successfully on this
-     *         ServletContext, and false if it was not set because this ServletContext already contains a context
-     *         initialization parameter with a matching name
+     * ServletContext, and false if it was not set because this ServletContext already contains a context initialization
+     * parameter with a matching name
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws NullPointerException          if the name parameter is {@code null}
+     * @throws NullPointerException if the name parameter is {@code null}
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
     public boolean setInitParameter(String name, String value);
 
     /**
-     * Returns the servlet container attribute with the given name, or <code>null</code> if there is no attribute by
-     * that name.
+     * Returns the servlet container attribute with the given name, or <code>null</code> if there is no attribute by that
+     * name.
      *
      * <p>
      * An attribute allows a servlet container to give the servlet additional information not already provided by this
-     * interface. See your server documentation for information about its attributes. A list of supported attributes can
-     * be retrieved using <code>getAttributeNames</code>.
+     * interface. See your server documentation for information about its attributes. A list of supported attributes can be
+     * retrieved using <code>getAttributeNames</code>.
      *
      * <p>
      * The attribute is returned as a <code>java.lang.Object</code> or some subclass.
      *
      * <p>
-     * Attribute names should follow the same convention as package names. The Jakarta Servlet specification reserves
-     * names matching <code>java.*</code>, <code>javax.*</code>, and <code>sun.*</code>.
+     * Attribute names should follow the same convention as package names. The Jakarta Servlet specification reserves names
+     * matching <code>java.*</code>, <code>javax.*</code>, and <code>sun.*</code>.
      *
      * @param name a <code>String</code> specifying the name of the attribute
      *
      * @return an <code>Object</code> containing the value of the attribute, or <code>null</code> if no attribute exists
-     *         matching the given name.
+     * matching the given name.
      *
      * @see ServletContext#getAttributeNames
      *
@@ -577,10 +571,10 @@ public interface ServletContext {
      * If a null value is passed, the effect is the same as calling <code>removeAttribute()</code>.
      *
      * <p>
-     * Attribute names should follow the same convention as package names. The Jakarta Servlet specification reserves
-     * names matching <code>java.*</code>, <code>javax.*</code>, and <code>sun.*</code>.
+     * Attribute names should follow the same convention as package names. The Jakarta Servlet specification reserves names
+     * matching <code>java.*</code>, <code>javax.*</code>, and <code>sun.*</code>.
      *
-     * @param name   a <code>String</code> specifying the name of the attribute
+     * @param name a <code>String</code> specifying the name of the attribute
      *
      * @param object an <code>Object</code> representing the attribute to be bound
      *
@@ -617,8 +611,8 @@ public interface ServletContext {
      * The registered servlet may be further configured via the returned {@link ServletRegistration} object.
      *
      * <p>
-     * The specified <tt>className</tt> will be loaded using the classloader associated with the application represented
-     * by this ServletContext.
+     * The specified <tt>className</tt> will be loaded using the classloader associated with the application represented by
+     * this ServletContext.
      *
      * <p>
      * If this ServletContext already contains a preliminary ServletRegistration for a servlet with the given
@@ -628,26 +622,25 @@ public interface ServletContext {
      * This method introspects the class with the given <tt>className</tt> for the
      * {@link jakarta.servlet.annotation.ServletSecurity}, {@link jakarta.servlet.annotation.MultipartConfig},
      * <tt>javax.annotation.security.RunAs</tt>, and <tt>javax.annotation.security.DeclareRoles</tt> annotations. In
-     * addition, this method supports resource injection if the class with the given <tt>className</tt> represents a
-     * Managed Bean. See the Jakarta EE platform and CDI specifications for additional details about Managed Beans and
-     * resource injection.
+     * addition, this method supports resource injection if the class with the given <tt>className</tt> represents a Managed
+     * Bean. See the Jakarta EE platform and CDI specifications for additional details about Managed Beans and resource
+     * injection.
      *
      * @param servletName the name of the servlet
-     * @param className   the fully qualified class name of the servlet
+     * @param className the fully qualified class name of the servlet
      *
-     * @return a ServletRegistration object that may be used to further configure the registered servlet, or
-     *         <tt>null</tt> if this ServletContext already contains a complete ServletRegistration for a servlet with
-     *         the given <tt>servletName</tt>
+     * @return a ServletRegistration object that may be used to further configure the registered servlet, or <tt>null</tt>
+     * if this ServletContext already contains a complete ServletRegistration for a servlet with the given
+     * <tt>servletName</tt>
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws IllegalArgumentException      if <code>servletName</code> is null or an empty String
+     * @throws IllegalArgumentException if <code>servletName</code> is null or an empty String
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -665,23 +658,21 @@ public interface ServletContext {
      * returned.
      *
      * @param servletName the name of the servlet
-     * @param servlet     the servlet instance to register
+     * @param servlet the servlet instance to register
      *
      * @return a ServletRegistration object that may be used to further configure the given servlet, or <tt>null</tt> if
-     *         this ServletContext already contains a complete ServletRegistration for a servlet with the given
-     *         <tt>servletName</tt> or if the same servlet instance has already been registered with this or another
-     *         ServletContext in the same container
+     * this ServletContext already contains a complete ServletRegistration for a servlet with the given <tt>servletName</tt>
+     * or if the same servlet instance has already been registered with this or another ServletContext in the same container
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
-     * @throws IllegalArgumentException      if the given servlet instance implements {@link SingleThreadModel}, or
-     *                                       <code>servletName</code> is null or an empty String
+     * @throws IllegalArgumentException if the given servlet instance implements {@link SingleThreadModel}, or
+     * <code>servletName</code> is null or an empty String
      *
      * @since Servlet 3.0
      */
@@ -701,26 +692,24 @@ public interface ServletContext {
      * <p>
      * This method introspects the given <tt>servletClass</tt> for the {@link jakarta.servlet.annotation.ServletSecurity},
      * {@link jakarta.servlet.annotation.MultipartConfig}, <tt>javax.annotation.security.RunAs</tt>, and
-     * <tt>javax.annotation.security.DeclareRoles</tt> annotations. In addition, this method supports resource injection
-     * if the given <tt>servletClass</tt> represents a Managed Bean. See the Jakarta EE platform and CDI specifications
-     * for additional details about Managed Beans and resource injection.
+     * <tt>javax.annotation.security.DeclareRoles</tt> annotations. In addition, this method supports resource injection if
+     * the given <tt>servletClass</tt> represents a Managed Bean. See the Jakarta EE platform and CDI specifications for
+     * additional details about Managed Beans and resource injection.
      *
-     * @param servletName  the name of the servlet
+     * @param servletName the name of the servlet
      * @param servletClass the class object from which the servlet will be instantiated
      *
-     * @return a ServletRegistration object that may be used to further configure the registered servlet, or
-     *         <tt>null</tt> if this ServletContext already contains a complete ServletRegistration for the given
-     *         <tt>servletName</tt>
+     * @return a ServletRegistration object that may be used to further configure the registered servlet, or <tt>null</tt>
+     * if this ServletContext already contains a complete ServletRegistration for the given <tt>servletName</tt>
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws IllegalArgumentException      if <code>servletName</code> is null or an empty String
+     * @throws IllegalArgumentException if <code>servletName</code> is null or an empty String
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -737,21 +726,20 @@ public interface ServletContext {
      * <tt>servletName</tt>, it will be completed (by assigning the given <tt>jspFile</tt> to it) and returned.
      *
      * @param servletName the name of the servlet
-     * @param jspFile     the full path to a JSP file within the web application beginning with a `/'.
+     * @param jspFile the full path to a JSP file within the web application beginning with a `/'.
      *
-     * @return a ServletRegistration object that may be used to further configure the registered servlet, or
-     *         <tt>null</tt> if this ServletContext already contains a complete ServletRegistration for a servlet with
-     *         the given <tt>servletName</tt>
+     * @return a ServletRegistration object that may be used to further configure the registered servlet, or <tt>null</tt>
+     * if this ServletContext already contains a complete ServletRegistration for a servlet with the given
+     * <tt>servletName</tt>
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws IllegalArgumentException      if <code>servletName</code> is null or an empty String
+     * @throws IllegalArgumentException if <code>servletName</code> is null or an empty String
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */
@@ -761,8 +749,8 @@ public interface ServletContext {
      * Instantiates the given Servlet class.
      *
      * <p>
-     * The returned Servlet instance may be further customized before it is registered with this ServletContext via a
-     * call to {@link #addServlet(String,Servlet)}.
+     * The returned Servlet instance may be further customized before it is registered with this ServletContext via a call
+     * to {@link #addServlet(String,Servlet)}.
      *
      * <p>
      * The given Servlet class must define a zero argument constructor, which is used to instantiate it.
@@ -771,21 +759,20 @@ public interface ServletContext {
      * This method introspects the given <tt>clazz</tt> for the following annotations:
      * {@link jakarta.servlet.annotation.ServletSecurity}, {@link jakarta.servlet.annotation.MultipartConfig},
      * <tt>javax.annotation.security.RunAs</tt>, and <tt>javax.annotation.security.DeclareRoles</tt>. In addition, this
-     * method supports resource injection if the given <tt>clazz</tt> represents a Managed Bean. See the Jakarta EE
-     * platform and CDI specifications for additional details about Managed Beans and resource injection.
+     * method supports resource injection if the given <tt>clazz</tt> represents a Managed Bean. See the Jakarta EE platform
+     * and CDI specifications for additional details about Managed Beans and resource injection.
      *
-     * @param       <T> the class of the Servlet to create
+     * @param <T> the class of the Servlet to create
      * @param clazz the Servlet class to instantiate
      *
      * @return the new Servlet instance
      *
-     * @throws ServletException              if the given <tt>clazz</tt> fails to be instantiated
+     * @throws ServletException if the given <tt>clazz</tt> fails to be instantiated
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -797,38 +784,36 @@ public interface ServletContext {
      * @param servletName the name of a servlet
      *
      * @return the (complete or preliminary) ServletRegistration for the servlet with the given <tt>servletName</tt>, or
-     *         null if no ServletRegistration exists under that name
+     * null if no ServletRegistration exists under that name
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
     public ServletRegistration getServletRegistration(String servletName);
 
     /**
-     * Gets a (possibly empty) Map of the ServletRegistration objects (keyed by servlet name) corresponding to all
-     * servlets registered with this ServletContext.
+     * Gets a (possibly empty) Map of the ServletRegistration objects (keyed by servlet name) corresponding to all servlets
+     * registered with this ServletContext.
      *
      * <p>
-     * The returned Map includes the ServletRegistration objects corresponding to all declared and annotated servlets,
-     * as well as the ServletRegistration objects corresponding to all servlets that have been added via one of the
+     * The returned Map includes the ServletRegistration objects corresponding to all declared and annotated servlets, as
+     * well as the ServletRegistration objects corresponding to all servlets that have been added via one of the
      * <tt>addServlet</tt> and <tt>addJspFile</tt> methods.
      *
      * <p>
      * If permitted, any changes to the returned Map must not affect this ServletContext.
      *
      * @return Map of the (complete and preliminary) ServletRegistration objects corresponding to all servlets currently
-     *         registered with this ServletContext
+     * registered with this ServletContext
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -841,34 +826,31 @@ public interface ServletContext {
      * The registered filter may be further configured via the returned {@link FilterRegistration} object.
      *
      * <p>
-     * The specified <tt>className</tt> will be loaded using the classloader associated with the application represented
-     * by this ServletContext.
+     * The specified <tt>className</tt> will be loaded using the classloader associated with the application represented by
+     * this ServletContext.
      *
      * <p>
      * If this ServletContext already contains a preliminary FilterRegistration for a filter with the given
      * <tt>filterName</tt>, it will be completed (by assigning the given <tt>className</tt> to it) and returned.
      *
      * <p>
-     * This method supports resource injection if the class with the given <tt>className</tt> represents a Managed Bean.
-     * See the Jakarta EE platform and CDI specifications for additional details about Managed Beans and resource
-     * injection.
+     * This method supports resource injection if the class with the given <tt>className</tt> represents a Managed Bean. See
+     * the Jakarta EE platform and CDI specifications for additional details about Managed Beans and resource injection.
      *
      * @param filterName the name of the filter
-     * @param className  the fully qualified class name of the filter
+     * @param className the fully qualified class name of the filter
      *
-     * @return a FilterRegistration object that may be used to further configure the registered filter, or <tt>null</tt>
-     *         if this ServletContext already contains a complete FilterRegistration for a filter with the given
-     *         <tt>filterName</tt>
+     * @return a FilterRegistration object that may be used to further configure the registered filter, or <tt>null</tt> if
+     * this ServletContext already contains a complete FilterRegistration for a filter with the given <tt>filterName</tt>
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws IllegalArgumentException      if <code>filterName</code> is null or an empty String
+     * @throws IllegalArgumentException if <code>filterName</code> is null or an empty String
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -886,22 +868,20 @@ public interface ServletContext {
      * returned.
      *
      * @param filterName the name of the filter
-     * @param filter     the filter instance to register
+     * @param filter the filter instance to register
      *
-     * @return a FilterRegistration object that may be used to further configure the given filter, or <tt>null</tt> if
-     *         this ServletContext already contains a complete FilterRegistration for a filter with the given
-     *         <tt>filterName</tt> or if the same filter instance has already been registered with this or another
-     *         ServletContext in the same container
+     * @return a FilterRegistration object that may be used to further configure the given filter, or <tt>null</tt> if this
+     * ServletContext already contains a complete FilterRegistration for a filter with the given <tt>filterName</tt> or if
+     * the same filter instance has already been registered with this or another ServletContext in the same container
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws IllegalArgumentException      if <code>filterName</code> is null or an empty String
+     * @throws IllegalArgumentException if <code>filterName</code> is null or an empty String
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -919,25 +899,23 @@ public interface ServletContext {
      * returned.
      *
      * <p>
-     * This method supports resource injection if the given <tt>filterClass</tt> represents a Managed Bean. See the Java
-     * EE platform and CDI specifications for additional details about Managed Beans and resource injection.
+     * This method supports resource injection if the given <tt>filterClass</tt> represents a Managed Bean. See the Java EE
+     * platform and CDI specifications for additional details about Managed Beans and resource injection.
      *
-     * @param filterName  the name of the filter
+     * @param filterName the name of the filter
      * @param filterClass the class object from which the filter will be instantiated
      *
-     * @return a FilterRegistration object that may be used to further configure the registered filter, or <tt>null</tt>
-     *         if this ServletContext already contains a complete FilterRegistration for a filter with the given
-     *         <tt>filterName</tt>
+     * @return a FilterRegistration object that may be used to further configure the registered filter, or <tt>null</tt> if
+     * this ServletContext already contains a complete FilterRegistration for a filter with the given <tt>filterName</tt>
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
-     * @throws IllegalArgumentException      if <code>filterName</code> is null or an empty String
+     * @throws IllegalArgumentException if <code>filterName</code> is null or an empty String
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -947,8 +925,8 @@ public interface ServletContext {
      * Instantiates the given Filter class.
      *
      * <p>
-     * The returned Filter instance may be further customized before it is registered with this ServletContext via a
-     * call to {@link #addFilter(String,Filter)}.
+     * The returned Filter instance may be further customized before it is registered with this ServletContext via a call to
+     * {@link #addFilter(String,Filter)}.
      *
      * <p>
      * The given Filter class must define a zero argument constructor, which is used to instantiate it.
@@ -957,18 +935,17 @@ public interface ServletContext {
      * This method supports resource injection if the given <tt>clazz</tt> represents a Managed Bean. See the Jakarta EE
      * platform and CDI specifications for additional details about Managed Beans and resource injection.
      *
-     * @param       <T> the class of the Filter to create
+     * @param <T> the class of the Filter to create
      * @param clazz the Filter class to instantiate
      *
      * @return the new Filter instance
      *
-     * @throws ServletException              if the given <tt>clazz</tt> fails to be instantiated
+     * @throws ServletException if the given <tt>clazz</tt> fails to be instantiated
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -978,14 +955,13 @@ public interface ServletContext {
      * Gets the FilterRegistration corresponding to the filter with the given <tt>filterName</tt>.
      *
      * @param filterName the name of a filter
-     * @return the (complete or preliminary) FilterRegistration for the filter with the given <tt>filterName</tt>, or
-     *         null if no FilterRegistration exists under that name
+     * @return the (complete or preliminary) FilterRegistration for the filter with the given <tt>filterName</tt>, or null
+     * if no FilterRegistration exists under that name
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -996,41 +972,39 @@ public interface ServletContext {
      * registered with this ServletContext.
      *
      * <p>
-     * The returned Map includes the FilterRegistration objects corresponding to all declared and annotated filters, as
-     * well as the FilterRegistration objects corresponding to all filters that have been added via one of the
-     * <tt>addFilter</tt> methods.
+     * The returned Map includes the FilterRegistration objects corresponding to all declared and annotated filters, as well
+     * as the FilterRegistration objects corresponding to all filters that have been added via one of the <tt>addFilter</tt>
+     * methods.
      *
      * <p>
      * Any changes to the returned Map must not affect this ServletContext.
      *
      * @return Map of the (complete and preliminary) FilterRegistration objects corresponding to all filters currently
-     *         registered with this ServletContext
+     * registered with this ServletContext
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
     public Map<String, ? extends FilterRegistration> getFilterRegistrations();
 
     /**
-     * Gets the {@link SessionCookieConfig} object through which various properties of the session tracking cookies
-     * created on behalf of this <tt>ServletContext</tt> may be configured.
+     * Gets the {@link SessionCookieConfig} object through which various properties of the session tracking cookies created
+     * on behalf of this <tt>ServletContext</tt> may be configured.
      *
      * <p>
      * Repeated invocations of this method will return the same <tt>SessionCookieConfig</tt> instance.
      *
      * @return the <tt>SessionCookieConfig</tt> object through which various properties of the session tracking cookies
-     *         created on behalf of this <tt>ServletContext</tt> may be configured
+     * created on behalf of this <tt>ServletContext</tt> may be configured
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -1043,22 +1017,18 @@ public interface ServletContext {
      * The given <tt>sessionTrackingModes</tt> replaces any session tracking modes set by a previous invocation of this
      * method on this <tt>ServletContext</tt>.
      *
-     * @param sessionTrackingModes the set of session tracking modes to become effective for this
-     *                             <tt>ServletContext</tt>
+     * @param sessionTrackingModes the set of session tracking modes to become effective for this <tt>ServletContext</tt>
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
-     * @throws IllegalArgumentException      if <tt>sessionTrackingModes</tt> specifies a combination of
-     *                                       <tt>SessionTrackingMode.SSL</tt> with a session tracking mode other than
-     *                                       <tt>SessionTrackingMode.SSL</tt>, or if <tt>sessionTrackingModes</tt>
-     *                                       specifies a session tracking mode that is not supported by the servlet
-     *                                       container
+     * @throws IllegalArgumentException if <tt>sessionTrackingModes</tt> specifies a combination of
+     * <tt>SessionTrackingMode.SSL</tt> with a session tracking mode other than <tt>SessionTrackingMode.SSL</tt>, or if
+     * <tt>sessionTrackingModes</tt> specifies a session tracking mode that is not supported by the servlet container
      *
      * @since Servlet 3.0
      */
@@ -1068,17 +1038,16 @@ public interface ServletContext {
      * Gets the session tracking modes that are supported by default for this <tt>ServletContext</tt>.
      *
      * <p>
-     * The returned set is not backed by the {@code ServletContext} object, so changes in the returned set are not
-     * reflected in the {@code ServletContext} object, and vice-versa.
+     * The returned set is not backed by the {@code ServletContext} object, so changes in the returned set are not reflected
+     * in the {@code ServletContext} object, and vice-versa.
      * </p>
      *
      * @return set of the session tracking modes supported by default for this <tt>ServletContext</tt>
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -1088,21 +1057,19 @@ public interface ServletContext {
      * Gets the session tracking modes that are in effect for this <tt>ServletContext</tt>.
      *
      * <p>
-     * The session tracking modes in effect are those provided to {@link #setSessionTrackingModes
-     * setSessionTrackingModes}.
+     * The session tracking modes in effect are those provided to {@link #setSessionTrackingModes setSessionTrackingModes}.
      *
      * <p>
-     * The returned set is not backed by the {@code ServletContext} object, so changes in the returned set are not
-     * reflected in the {@code ServletContext} object, and vice-versa.
+     * The returned set is not backed by the {@code ServletContext} object, so changes in the returned set are not reflected
+     * in the {@code ServletContext} object, and vice-versa.
      * </p>
      *
      * @return set of the session tracking modes in effect for this <tt>ServletContext</tt>
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -1134,28 +1101,25 @@ public interface ServletContext {
      * <p>
      * If the class with the given name implements a listener interface whose invocation order corresponds to the
      * declaration order (i.e., if it implements {@link ServletRequestListener}, {@link ServletContextListener}, or
-     * {@link jakarta.servlet.http.HttpSessionListener}), then the new listener will be added to the end of the ordered
-     * list of listeners of that interface.
+     * {@link jakarta.servlet.http.HttpSessionListener}), then the new listener will be added to the end of the ordered list
+     * of listeners of that interface.
      *
      * <p>
-     * This method supports resource injection if the class with the given <tt>className</tt> represents a Managed Bean.
-     * See the Jakarta EE platform and CDI specifications for additional details about Managed Beans and resource
-     * injection.
+     * This method supports resource injection if the class with the given <tt>className</tt> represents a Managed Bean. See
+     * the Jakarta EE platform and CDI specifications for additional details about Managed Beans and resource injection.
      *
      * @param className the fully qualified class name of the listener
      *
-     * @throws IllegalArgumentException      if the class with the given name does not implement any of the above
-     *                                       interfaces, or if it implements {@link ServletContextListener} and this
-     *                                       ServletContext was not passed to
-     *                                       {@link ServletContainerInitializer#onStartup}
+     * @throws IllegalArgumentException if the class with the given name does not implement any of the above interfaces, or
+     * if it implements {@link ServletContextListener} and this ServletContext was not passed to
+     * {@link ServletContainerInitializer#onStartup}
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -1176,30 +1140,28 @@ public interface ServletContext {
      * </ul>
      *
      * <p>
-     * If this ServletContext was passed to {@link ServletContainerInitializer#onStartup}, then the given listener may
-     * also be an instance of {@link ServletContextListener}, in addition to the interfaces listed above.
+     * If this ServletContext was passed to {@link ServletContainerInitializer#onStartup}, then the given listener may also
+     * be an instance of {@link ServletContextListener}, in addition to the interfaces listed above.
      *
      * <p>
-     * If the given listener is an instance of a listener interface whose invocation order corresponds to the
-     * declaration order (i.e., if it is an instance of {@link ServletRequestListener}, {@link ServletContextListener},
-     * or {@link jakarta.servlet.http.HttpSessionListener}), then the listener will be added to the end of the ordered
-     * list of listeners of that interface.
+     * If the given listener is an instance of a listener interface whose invocation order corresponds to the declaration
+     * order (i.e., if it is an instance of {@link ServletRequestListener}, {@link ServletContextListener}, or
+     * {@link jakarta.servlet.http.HttpSessionListener}), then the listener will be added to the end of the ordered list of
+     * listeners of that interface.
      *
-     * @param   <T> the class of the EventListener to add
+     * @param <T> the class of the EventListener to add
      * @param t the listener to be added
      *
-     * @throws IllegalArgumentException      if the given listener is not an instance of any of the above interfaces, or
-     *                                       if it is an instance of {@link ServletContextListener} and this
-     *                                       ServletContext was not passed to
-     *                                       {@link ServletContainerInitializer#onStartup}
+     * @throws IllegalArgumentException if the given listener is not an instance of any of the above interfaces, or if it is
+     * an instance of {@link ServletContextListener} and this ServletContext was not passed to
+     * {@link ServletContainerInitializer#onStartup}
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -1221,14 +1183,13 @@ public interface ServletContext {
      *
      * <p>
      * If this ServletContext was passed to {@link ServletContainerInitializer#onStartup}, then the given
-     * <tt>listenerClass</tt> may also implement {@link ServletContextListener}, in addition to the interfaces listed
-     * above.
+     * <tt>listenerClass</tt> may also implement {@link ServletContextListener}, in addition to the interfaces listed above.
      *
      * <p>
      * If the given <tt>listenerClass</tt> implements a listener interface whose invocation order corresponds to the
      * declaration order (i.e., if it implements {@link ServletRequestListener}, {@link ServletContextListener}, or
-     * {@link jakarta.servlet.http.HttpSessionListener}), then the new listener will be added to the end of the ordered
-     * list of listeners of that interface.
+     * {@link jakarta.servlet.http.HttpSessionListener}), then the new listener will be added to the end of the ordered list
+     * of listeners of that interface.
      *
      * <p>
      * This method supports resource injection if the given <tt>listenerClass</tt> represents a Managed Bean. See the
@@ -1236,18 +1197,16 @@ public interface ServletContext {
      *
      * @param listenerClass the listener class to be instantiated
      *
-     * @throws IllegalArgumentException      if the given <tt>listenerClass</tt> does not implement any of the above
-     *                                       interfaces, or if it implements {@link ServletContextListener} and this
-     *                                       ServletContext was not passed to
-     *                                       {@link ServletContainerInitializer#onStartup}
+     * @throws IllegalArgumentException if the given <tt>listenerClass</tt> does not implement any of the above interfaces,
+     * or if it implements {@link ServletContextListener} and this ServletContext was not passed to
+     * {@link ServletContainerInitializer#onStartup}
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.0
      */
@@ -1263,8 +1222,8 @@ public interface ServletContext {
      * {@link jakarta.servlet.http.HttpSessionListener} interfaces.
      *
      * <p>
-     * The returned EventListener instance may be further customized before it is registered with this ServletContext
-     * via a call to {@link #addListener(EventListener)}.
+     * The returned EventListener instance may be further customized before it is registered with this ServletContext via a
+     * call to {@link #addListener(EventListener)}.
      *
      * <p>
      * The given EventListener class must define a zero argument constructor, which is used to instantiate it.
@@ -1273,43 +1232,39 @@ public interface ServletContext {
      * This method supports resource injection if the given <tt>clazz</tt> represents a Managed Bean. See the Jakarta EE
      * platform and CDI specifications for additional details about Managed Beans and resource injection.
      *
-     * @param       <T> the class of the EventListener to create
+     * @param <T> the class of the EventListener to create
      * @param clazz the EventListener class to instantiate
      *
      * @return the new EventListener instance
      *
-     * @throws ServletException              if the given <tt>clazz</tt> fails to be instantiated
+     * @throws ServletException if the given <tt>clazz</tt> fails to be instantiated
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
-     * @throws IllegalArgumentException      if the specified EventListener class does not implement any of the
-     *                                       {@link ServletContextListener}, {@link ServletContextAttributeListener},
-     *                                       {@link ServletRequestListener}, {@link ServletRequestAttributeListener},
-     *                                       {@link jakarta.servlet.http.HttpSessionAttributeListener},
-     *                                       {@link jakarta.servlet.http.HttpSessionIdListener}, or
-     *                                       {@link jakarta.servlet.http.HttpSessionListener} interfaces.
+     * @throws IllegalArgumentException if the specified EventListener class does not implement any of the
+     * {@link ServletContextListener}, {@link ServletContextAttributeListener}, {@link ServletRequestListener},
+     * {@link ServletRequestAttributeListener}, {@link jakarta.servlet.http.HttpSessionAttributeListener},
+     * {@link jakarta.servlet.http.HttpSessionIdListener}, or {@link jakarta.servlet.http.HttpSessionListener} interfaces.
      *
      * @since Servlet 3.0
      */
     public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException;
 
     /**
-     * Gets the <code>&lt;jsp-config&gt;</code> related configuration that was aggregated from the <code>web.xml</code>
-     * and <code>web-fragment.xml</code> descriptor files of the web application represented by this ServletContext.
+     * Gets the <code>&lt;jsp-config&gt;</code> related configuration that was aggregated from the <code>web.xml</code> and
+     * <code>web-fragment.xml</code> descriptor files of the web application represented by this ServletContext.
      *
-     * @return the <code>&lt;jsp-config&gt;</code> related configuration that was aggregated from the
-     *         <code>web.xml</code> and <code>web-fragment.xml</code> descriptor files of the web application
-     *         represented by this ServletContext, or null if no such configuration exists
+     * @return the <code>&lt;jsp-config&gt;</code> related configuration that was aggregated from the <code>web.xml</code>
+     * and <code>web-fragment.xml</code> descriptor files of the web application represented by this ServletContext, or null
+     * if no such configuration exists
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @see jakarta.servlet.descriptor.JspConfigDescriptor
      *
@@ -1321,20 +1276,19 @@ public interface ServletContext {
      * Gets the class loader of the web application represented by this ServletContext.
      *
      * <p>
-     * If a security manager exists, and the caller's class loader is not the same as, or an ancestor of the requested
-     * class loader, then the security manager's <code>checkPermission</code> method is called with a
+     * If a security manager exists, and the caller's class loader is not the same as, or an ancestor of the requested class
+     * loader, then the security manager's <code>checkPermission</code> method is called with a
      * <code>RuntimePermission("getClassLoader")</code> permission to check whether access to the requested class loader
      * should be granted.
      *
      * @return the class loader of the web application represented by this ServletContext
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
-     * @throws SecurityException             if a security manager denies access to the requested class loader
+     * @throws SecurityException if a security manager denies access to the requested class loader
      *
      * @since Servlet 3.0
      */
@@ -1346,20 +1300,19 @@ public interface ServletContext {
      * <p>
      * Roles that are implicitly declared as a result of their use within the
      * {@link ServletRegistration.Dynamic#setServletSecurity setServletSecurity} or
-     * {@link ServletRegistration.Dynamic#setRunAsRole setRunAsRole} methods of the {@link ServletRegistration}
-     * interface need not be declared.
+     * {@link ServletRegistration.Dynamic#setRunAsRole setRunAsRole} methods of the {@link ServletRegistration} interface
+     * need not be declared.
      *
      * @param roleNames the role names being declared
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
-     * @throws IllegalArgumentException      if any of the argument roleNames is null or the empty string
+     * @throws IllegalArgumentException if any of the argument roleNames is null or the empty string
      *
-     * @throws IllegalStateException         if the ServletContext has already been initialized
+     * @throws IllegalStateException if the ServletContext has already been initialized
      *
      * @since Servlet 3.0
      */
@@ -1369,18 +1322,17 @@ public interface ServletContext {
      * Returns the configuration name of the logical host on which the ServletContext is deployed.
      *
      * Servlet containers may support multiple logical hosts. This method must return the same name for all the servlet
-     * contexts deployed on a logical host, and the name returned by this method must be distinct, stable per logical
-     * host, and suitable for use in associating server configuration information with the logical host. The returned
-     * value is NOT expected or required to be equivalent to a network address or hostname of the logical host.
+     * contexts deployed on a logical host, and the name returned by this method must be distinct, stable per logical host,
+     * and suitable for use in associating server configuration information with the logical host. The returned value is NOT
+     * expected or required to be equivalent to a network address or hostname of the logical host.
      *
-     * @return a <code>String</code> containing the configuration name of the logical host on which the servlet context
-     *         is deployed.
+     * @return a <code>String</code> containing the configuration name of the logical host on which the servlet context is
+     * deployed.
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 3.1
      */
@@ -1392,10 +1344,9 @@ public interface ServletContext {
      * @return the session timeout in minutes that are supported by default for this <tt>ServletContext</tt>
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */
@@ -1406,13 +1357,12 @@ public interface ServletContext {
      *
      * @param sessionTimeout session timeout in minutes
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */
@@ -1426,10 +1376,9 @@ public interface ServletContext {
      * @return the request character encoding that are supported by default for this <tt>ServletContext</tt>
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */
@@ -1440,13 +1389,12 @@ public interface ServletContext {
      *
      * @param encoding request character encoding
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */
@@ -1460,10 +1408,9 @@ public interface ServletContext {
      * @return the request character encoding that are supported by default for this <tt>ServletContext</tt>
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */
@@ -1474,13 +1421,12 @@ public interface ServletContext {
      *
      * @param encoding response character encoding
      *
-     * @throws IllegalStateException         if this ServletContext has already been initialized
+     * @throws IllegalStateException if this ServletContext has already been initialized
      *
      * @throws UnsupportedOperationException if this ServletContext was passed to the
-     *                                       {@link ServletContextListener#contextInitialized} method of a
-     *                                       {@link ServletContextListener} that was neither declared in
-     *                                       <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
-     *                                       {@link jakarta.servlet.annotation.WebListener}
+     * {@link ServletContextListener#contextInitialized} method of a {@link ServletContextListener} that was neither
+     * declared in <code>web.xml</code> or <code>web-fragment.xml</code>, nor annotated with
+     * {@link jakarta.servlet.annotation.WebListener}
      *
      * @since Servlet 4.0
      */

--- a/api/src/main/java/jakarta/servlet/ServletContextAttributeEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextAttributeEvent.java
@@ -36,8 +36,8 @@ public class ServletContextAttributeEvent extends ServletContextEvent {
      * Constructs a ServletContextAttributeEvent from the given ServletContext, attribute name, and attribute value.
      *
      * @param source the ServletContext whose attribute changed
-     * @param name   the name of the ServletContext attribute that changed
-     * @param value  the value of the ServletContext attribute that changed
+     * @param name the name of the ServletContext attribute that changed
+     * @param value the value of the ServletContext attribute that changed
      */
     public ServletContextAttributeEvent(ServletContext source, String name, Object value) {
         super(source);
@@ -58,8 +58,8 @@ public class ServletContextAttributeEvent extends ServletContextEvent {
      * Gets the value of the ServletContext attribute that changed.
      *
      * <p>
-     * If the attribute was added, this is the value of the attribute. If the attribute was removed, this is the value
-     * of the removed attribute. If the attribute was replaced, this is the old value of the attribute.
+     * If the attribute was added, this is the value of the attribute. If the attribute was removed, this is the value of
+     * the removed attribute. If the attribute was replaced, this is the old value of the attribute.
      *
      * @return the value of the ServletContext attribute that changed
      */

--- a/api/src/main/java/jakarta/servlet/ServletContextAttributeListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextAttributeListener.java
@@ -25,8 +25,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link ServletContext}.
  *
  * <p>
  * The order in which implementations of this interface are invoked is unspecified.
@@ -40,8 +40,8 @@ public interface ServletContextAttributeListener extends EventListener {
     /**
      * Receives notification that an attribute has been added to the ServletContext.
      *
-     * @param event the ServletContextAttributeEvent containing the ServletContext to which the attribute was added,
-     *              along with the attribute name and value
+     * @param event the ServletContextAttributeEvent containing the ServletContext to which the attribute was added, along
+     * with the attribute name and value
      *
      * @implSpec The default implementation takes no action.
      */
@@ -52,7 +52,7 @@ public interface ServletContextAttributeListener extends EventListener {
      * Receives notification that an attribute has been removed from the ServletContext.
      *
      * @param event the ServletContextAttributeEvent containing the ServletContext from which the attribute was removed,
-     *              along with the attribute name and value
+     * along with the attribute name and value
      *
      * @implSpec The default implementation takes no action.
      */
@@ -63,7 +63,7 @@ public interface ServletContextAttributeListener extends EventListener {
      * Receives notification that an attribute has been replaced in the ServletContext.
      *
      * @param event the ServletContextAttributeEvent containing the ServletContext in which the attribute was replaced,
-     *              along with the attribute name and its old value
+     * along with the attribute name and its old value
      *
      * @implSpec The default implementation takes no action.
      */

--- a/api/src/main/java/jakarta/servlet/ServletContextListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletContextListener.java
@@ -25,8 +25,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link ServletContext}.
  *
  * <p>
  * Implementations of this interface are invoked at their {@link #contextInitialized} method in the order in which they

--- a/api/src/main/java/jakarta/servlet/ServletException.java
+++ b/api/src/main/java/jakarta/servlet/ServletException.java
@@ -38,8 +38,8 @@ public class ServletException extends Exception {
     }
 
     /**
-     * Constructs a new servlet exception with the specified message. The message can be written to the server log
-     * and/or displayed for the user.
+     * Constructs a new servlet exception with the specified message. The message can be written to the server log and/or
+     * displayed for the user.
      *
      * @param message a <code>String</code> specifying the text of the exception message
      *
@@ -49,14 +49,14 @@ public class ServletException extends Exception {
     }
 
     /**
-     * Constructs a new servlet exception when the servlet needs to throw an exception and include a message about the
-     * "root cause" exception that interfered with its normal operation, including a description message.
+     * Constructs a new servlet exception when the servlet needs to throw an exception and include a message about the "root
+     * cause" exception that interfered with its normal operation, including a description message.
      *
      *
-     * @param message   a <code>String</code> containing the text of the exception message
+     * @param message a <code>String</code> containing the text of the exception message
      *
      * @param rootCause the <code>Throwable</code> exception that interfered with the servlet's normal operation, making
-     *                  this servlet exception necessary
+     * this servlet exception necessary
      *
      */
     public ServletException(String message, Throwable rootCause) {
@@ -65,17 +65,17 @@ public class ServletException extends Exception {
     }
 
     /**
-     * Constructs a new servlet exception when the servlet needs to throw an exception and include a message about the
-     * "root cause" exception that interfered with its normal operation. The exception's message is based on the
-     * localized message of the underlying exception.
+     * Constructs a new servlet exception when the servlet needs to throw an exception and include a message about the "root
+     * cause" exception that interfered with its normal operation. The exception's message is based on the localized message
+     * of the underlying exception.
      *
      * <p>
      * This method calls the <code>getLocalizedMessage</code> method on the <code>Throwable</code> exception to get a
-     * localized exception message. When subclassing <code>ServletException</code>, this method can be overridden to
-     * create an exception message designed for a specific locale.
+     * localized exception message. When subclassing <code>ServletException</code>, this method can be overridden to create
+     * an exception message designed for a specific locale.
      *
-     * @param rootCause the <code>Throwable</code> exception that interfered with the servlet's normal operation, making
-     *                  the servlet exception necessary
+     * @param rootCause the <code>Throwable</code> exception that interfered with the servlet's normal operation, making the
+     * servlet exception necessary
      *
      */
     public ServletException(Throwable rootCause) {

--- a/api/src/main/java/jakarta/servlet/ServletInputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletInputStream.java
@@ -18,8 +18,8 @@
 
 package jakarta.servlet;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * 
@@ -60,7 +60,7 @@ public abstract class ServletInputStream extends InputStream {
      *
      *
      *
-     * @param b   an array of bytes into which data is read
+     * @param b an array of bytes into which data is read
      *
      * @param off an integer specifying the character at which this method begins reading
      *
@@ -92,7 +92,7 @@ public abstract class ServletInputStream extends InputStream {
      * Returns true when all the data from the stream has been read else it returns false.
      *
      * @return <code>true</code> when all data for this particular request has been read, otherwise returns
-     *         <code>false</code>.
+     * <code>false</code>.
      *
      * @since Servlet 3.1
      */
@@ -108,17 +108,15 @@ public abstract class ServletInputStream extends InputStream {
     public abstract boolean isReady();
 
     /**
-     * Instructs the <code>ServletInputStream</code> to invoke the provided {@link ReadListener} when it is possible to
-     * read
+     * Instructs the <code>ServletInputStream</code> to invoke the provided {@link ReadListener} when it is possible to read
      *
      * @param readListener the {@link ReadListener} that should be notified when it's possible to read.
      *
      * @exception IllegalStateException if one of the following conditions is true
-     *                                  <ul>
-     *                                  <li>the associated request is neither upgraded nor the async started
-     *                                  <li>setReadListener is called more than once within the scope of the same
-     *                                  request.
-     *                                  </ul>
+     * <ul>
+     * <li>the associated request is neither upgraded nor the async started
+     * <li>setReadListener is called more than once within the scope of the same request.
+     * </ul>
      *
      * @throws NullPointerException if readListener is null
      *

--- a/api/src/main/java/jakarta/servlet/ServletOutputStream.java
+++ b/api/src/main/java/jakarta/servlet/ServletOutputStream.java
@@ -83,7 +83,7 @@ public abstract class ServletOutputStream extends OutputStream {
             }
             out[i] = (byte) (0xff & c);
         }
-        write(out,0,len);
+        write(out, 0, len);
     }
 
     /**
@@ -275,25 +275,24 @@ public abstract class ServletOutputStream extends OutputStream {
      * This method can be used to determine if data can be written without blocking.
      *
      * @return <code>true</code> if a write to this <code>ServletOutputStream</code> will succeed, otherwise returns
-     *         <code>false</code>.
+     * <code>false</code>.
      *
      * @since Servlet 3.1
      */
     public abstract boolean isReady();
 
     /**
-     * Instructs the <code>ServletOutputStream</code> to invoke the provided {@link WriteListener} when it is possible
-     * to write
+     * Instructs the <code>ServletOutputStream</code> to invoke the provided {@link WriteListener} when it is possible to
+     * write
      *
      *
      * @param writeListener the {@link WriteListener} that should be notified when it's possible to write
      *
      * @exception IllegalStateException if one of the following conditions is true
-     *                                  <ul>
-     *                                  <li>the associated request is neither upgraded nor the async started
-     *                                  <li>setWriteListener is called more than once within the scope of the same
-     *                                  request.
-     *                                  </ul>
+     * <ul>
+     * <li>the associated request is neither upgraded nor the async started
+     * <li>setWriteListener is called more than once within the scope of the same request.
+     * </ul>
      *
      * @throws NullPointerException if writeListener is null
      *

--- a/api/src/main/java/jakarta/servlet/ServletRegistration.java
+++ b/api/src/main/java/jakarta/servlet/ServletRegistration.java
@@ -45,8 +45,8 @@ public interface ServletRegistration extends Registration {
      * @return the (possibly empty) Set of URL patterns that are already mapped to a different Servlet
      *
      * @throws IllegalArgumentException if <tt>urlPatterns</tt> is null or empty
-     * @throws IllegalStateException    if the ServletContext from which this ServletRegistration was obtained has
-     *                                  already been initialized
+     * @throws IllegalStateException if the ServletContext from which this ServletRegistration was obtained has already been
+     * initialized
      */
     public Set<String> addMapping(String... urlPatterns);
 
@@ -57,8 +57,8 @@ public interface ServletRegistration extends Registration {
      * If permitted, any changes to the returned <code>Collection</code> must not affect this
      * <code>ServletRegistration</code>.
      *
-     * @return a (possibly empty) <code>Collection</code> of the currently available mappings of the Servlet represented
-     *         by this <code>ServletRegistration</code>
+     * @return a (possibly empty) <code>Collection</code> of the currently available mappings of the Servlet represented by
+     * this <code>ServletRegistration</code>
      */
     public Collection<String> getMappings();
 
@@ -81,12 +81,12 @@ public interface ServletRegistration extends Registration {
          * <p>
          * A <tt>loadOnStartup</tt> value of greater than or equal to zero indicates to the container the initialization
          * priority of the Servlet. In this case, the container must instantiate and initialize the Servlet during the
-         * initialization phase of the ServletContext, that is, after it has invoked all of the ServletContextListener
-         * objects configured for the ServletContext at their {@link ServletContextListener#contextInitialized} method.
+         * initialization phase of the ServletContext, that is, after it has invoked all of the ServletContextListener objects
+         * configured for the ServletContext at their {@link ServletContextListener#contextInitialized} method.
          *
          * <p>
-         * If <tt>loadOnStartup</tt> is a negative integer, the container is free to instantiate and initialize the
-         * Servlet lazily.
+         * If <tt>loadOnStartup</tt> is a negative integer, the container is free to instantiate and initialize the Servlet
+         * lazily.
          *
          * <p>
          * The default value for <tt>loadOnStartup</tt> is <code>-1</code>.
@@ -96,8 +96,8 @@ public interface ServletRegistration extends Registration {
          *
          * @param loadOnStartup the initialization priority of the Servlet
          *
-         * @throws IllegalStateException if the ServletContext from which this ServletRegistration was obtained has
-         *                               already been initialized
+         * @throws IllegalStateException if the ServletContext from which this ServletRegistration was obtained has already been
+         * initialized
          */
         public void setLoadOnStartup(int loadOnStartup);
 
@@ -106,57 +106,54 @@ public interface ServletRegistration extends Registration {
          * <code>ServletRegistration</code>.
          *
          * <p>
-         * This method applies to all mappings added to this <code>ServletRegistration</code> up until the point that
-         * the <code>ServletContext</code> from which it was obtained has been initialized.
+         * This method applies to all mappings added to this <code>ServletRegistration</code> up until the point that the
+         * <code>ServletContext</code> from which it was obtained has been initialized.
          * 
          * <p>
-         * If a URL pattern of this ServletRegistration is an exact target of a <code>security-constraint</code> that
-         * was established via the portable deployment descriptor, then this method does not change the
+         * If a URL pattern of this ServletRegistration is an exact target of a <code>security-constraint</code> that was
+         * established via the portable deployment descriptor, then this method does not change the
          * <code>security-constraint</code> for that pattern, and the pattern will be included in the return value.
          * 
          * <p>
-         * If a URL pattern of this ServletRegistration is an exact target of a security constraint that was established
-         * via the {@link jakarta.servlet.annotation.ServletSecurity} annotation or a previous call to this method, then
-         * this method replaces the security constraint for that pattern.
+         * If a URL pattern of this ServletRegistration is an exact target of a security constraint that was established via the
+         * {@link jakarta.servlet.annotation.ServletSecurity} annotation or a previous call to this method, then this method
+         * replaces the security constraint for that pattern.
          * 
          * <p>
          * If a URL pattern of this ServletRegistration is neither the exact target of a security constraint that was
-         * established via the {@link jakarta.servlet.annotation.ServletSecurity} annotation or a previous call to this
-         * method, nor the exact target of a <code>security-constraint</code> in the portable deployment descriptor,
-         * then this method establishes the security constraint for that pattern from the argument
-         * <code>ServletSecurityElement</code>.
+         * established via the {@link jakarta.servlet.annotation.ServletSecurity} annotation or a previous call to this method,
+         * nor the exact target of a <code>security-constraint</code> in the portable deployment descriptor, then this method
+         * establishes the security constraint for that pattern from the argument <code>ServletSecurityElement</code>.
          *
          * <p>
-         * The returned set is not backed by the {@code Dynamic} object, so changes in the returned set are not
-         * reflected in the {@code Dynamic} object, and vice-versa.
+         * The returned set is not backed by the {@code Dynamic} object, so changes in the returned set are not reflected in the
+         * {@code Dynamic} object, and vice-versa.
          * </p>
          * 
-         * @param constraint the {@link ServletSecurityElement} to be applied to the patterns mapped to this
-         *                   ServletRegistration
+         * @param constraint the {@link ServletSecurityElement} to be applied to the patterns mapped to this ServletRegistration
          * 
          * @return the (possibly empty) Set of URL patterns that were already the exact target of a
-         *         <code>security-constraint</code> that was established via the portable deployment descriptor. This
-         *         method has no effect on the patterns included in the returned set
+         * <code>security-constraint</code> that was established via the portable deployment descriptor. This method has no
+         * effect on the patterns included in the returned set
          * 
          * @throws IllegalArgumentException if <tt>constraint</tt> is null
          * 
-         * @throws IllegalStateException    if the {@link ServletContext} from which this
-         *                                  <code>ServletRegistration</code> was obtained has already been initialized
+         * @throws IllegalStateException if the {@link ServletContext} from which this <code>ServletRegistration</code> was
+         * obtained has already been initialized
          */
         public Set<String> setServletSecurity(ServletSecurityElement constraint);
 
         /**
          * Sets the {@link MultipartConfigElement} to be applied to the mappings defined for this
-         * <code>ServletRegistration</code>. If this method is called multiple times, each successive call overrides the
-         * effects of the former.
+         * <code>ServletRegistration</code>. If this method is called multiple times, each successive call overrides the effects
+         * of the former.
          *
-         * @param multipartConfig the {@link MultipartConfigElement} to be applied to the patterns mapped to the
-         *                        registration
+         * @param multipartConfig the {@link MultipartConfigElement} to be applied to the patterns mapped to the registration
          *
          * @throws IllegalArgumentException if <tt>multipartConfig</tt> is null
          *
-         * @throws IllegalStateException    if the {@link ServletContext} from which this ServletRegistration was
-         *                                  obtained has already been initialized
+         * @throws IllegalStateException if the {@link ServletContext} from which this ServletRegistration was obtained has
+         * already been initialized
          */
         public void setMultipartConfig(MultipartConfigElement multipartConfig);
 
@@ -167,8 +164,8 @@ public interface ServletRegistration extends Registration {
          *
          * @throws IllegalArgumentException if <tt>roleName</tt> is null
          *
-         * @throws IllegalStateException    if the {@link ServletContext} from which this ServletRegistration was
-         *                                  obtained has already been initialized
+         * @throws IllegalStateException if the {@link ServletContext} from which this ServletRegistration was obtained has
+         * already been initialized
          */
         public void setRunAsRole(String roleName);
 

--- a/api/src/main/java/jakarta/servlet/ServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequest.java
@@ -38,12 +38,12 @@ import java.util.*;
 public interface ServletRequest {
 
     /**
-     * Returns the value of the named attribute as an <code>Object</code>, or <code>null</code> if no attribute of the
-     * given name exists.
+     * Returns the value of the named attribute as an <code>Object</code>, or <code>null</code> if no attribute of the given
+     * name exists.
      *
      * <p>
-     * Attributes can be set two ways. The servlet container may set attributes to make available custom information
-     * about a request. For example, for requests made using HTTPS, the attribute
+     * Attributes can be set two ways. The servlet container may set attributes to make available custom information about a
+     * request. For example, for requests made using HTTPS, the attribute
      * <code>jakarta.servlet.request.X509Certificate</code> can be used to retrieve information on the certificate of the
      * client. Attributes can also be set programmatically using {@link ServletRequest#setAttribute}. This allows
      * information to be embedded into a request before a {@link RequestDispatcher} call.
@@ -54,8 +54,8 @@ public interface ServletRequest {
      *
      * @param name a <code>String</code> specifying the name of the attribute
      *
-     * @return an <code>Object</code> containing the value of the attribute, or <code>null</code> if the attribute does
-     *         not exist
+     * @return an <code>Object</code> containing the value of the attribute, or <code>null</code> if the attribute does not
+     * exist
      */
     public Object getAttribute(String name);
 
@@ -68,41 +68,40 @@ public interface ServletRequest {
     public Enumeration<String> getAttributeNames();
 
     /**
-     * Returns the name of the character encoding used in the body of this request. This method returns
-     * <code>null</code> if no request encoding character encoding has been specified. The following methods for
-     * specifying the request character encoding are consulted, in decreasing order of priority: per request, per web
-     * app (using {@link ServletContext#setRequestCharacterEncoding}, deployment descriptor), and per container (for all
-     * web applications deployed in that container, using vendor specific configuration).
+     * Returns the name of the character encoding used in the body of this request. This method returns <code>null</code> if
+     * no request encoding character encoding has been specified. The following methods for specifying the request character
+     * encoding are consulted, in decreasing order of priority: per request, per web app (using
+     * {@link ServletContext#setRequestCharacterEncoding}, deployment descriptor), and per container (for all web
+     * applications deployed in that container, using vendor specific configuration).
      * 
-     * @return a <code>String</code> containing the name of the character encoding, or <code>null</code> if the request
-     *         does not specify a character encoding
+     * @return a <code>String</code> containing the name of the character encoding, or <code>null</code> if the request does
+     * not specify a character encoding
      */
     public String getCharacterEncoding();
 
     /**
-     * Overrides the name of the character encoding used in the body of this request. This method must be called prior
-     * to reading request parameters or reading input using getReader(). Otherwise, it has no effect.
+     * Overrides the name of the character encoding used in the body of this request. This method must be called prior to
+     * reading request parameters or reading input using getReader(). Otherwise, it has no effect.
      * 
      * @param env <code>String</code> containing the name of the character encoding.
      *
      * @throws UnsupportedEncodingException if this ServletRequest is still in a state where a character encoding may be
-     *                                      set, but the specified encoding is invalid
+     * set, but the specified encoding is invalid
      */
     public void setCharacterEncoding(String env) throws UnsupportedEncodingException;
 
     /**
-     * Returns the length, in bytes, of the request body and made available by the input stream, or -1 if the length is
-     * not known or is greater than Integer.MAX_VALUE. For HTTP servlets, same as the value of the CGI variable
-     * CONTENT_LENGTH.
+     * Returns the length, in bytes, of the request body and made available by the input stream, or -1 if the length is not
+     * known or is greater than Integer.MAX_VALUE. For HTTP servlets, same as the value of the CGI variable CONTENT_LENGTH.
      *
      * @return an integer containing the length of the request body or -1 if the length is not known or is greater than
-     *         Integer.MAX_VALUE.
+     * Integer.MAX_VALUE.
      */
     public int getContentLength();
 
     /**
-     * Returns the length, in bytes, of the request body and made available by the input stream, or -1 if the length is
-     * not known. For HTTP servlets, same as the value of the CGI variable CONTENT_LENGTH.
+     * Returns the length, in bytes, of the request body and made available by the input stream, or -1 if the length is not
+     * known. For HTTP servlets, same as the value of the CGI variable CONTENT_LENGTH.
      *
      * @return a long containing the length of the request body or -1L if the length is not known
      *
@@ -111,11 +110,10 @@ public interface ServletRequest {
     public long getContentLengthLong();
 
     /**
-     * Returns the MIME type of the body of the request, or <code>null</code> if the type is not known. For HTTP
-     * servlets, same as the value of the CGI variable CONTENT_TYPE.
+     * Returns the MIME type of the body of the request, or <code>null</code> if the type is not known. For HTTP servlets,
+     * same as the value of the CGI variable CONTENT_TYPE.
      *
-     * @return a <code>String</code> containing the name of the MIME type of the request, or null if the type is not
-     *         known
+     * @return a <code>String</code> containing the name of the MIME type of the request, or null if the type is not known
      */
     public String getContentType();
 
@@ -127,26 +125,26 @@ public interface ServletRequest {
      *
      * @exception IllegalStateException if the {@link #getReader} method has already been called for this request
      *
-     * @exception IOException           if an input or output exception occurred
+     * @exception IOException if an input or output exception occurred
      */
     public ServletInputStream getInputStream() throws IOException;
 
     /**
      * Returns the value of a request parameter as a <code>String</code>, or <code>null</code> if the parameter does not
-     * exist. Request parameters are extra information sent with the request. For HTTP servlets, parameters are
-     * contained in the query string or posted form data.
+     * exist. Request parameters are extra information sent with the request. For HTTP servlets, parameters are contained in
+     * the query string or posted form data.
      *
      * <p>
-     * You should only use this method when you are sure the parameter has only one value. If the parameter might have
-     * more than one value, use {@link #getParameterValues}.
+     * You should only use this method when you are sure the parameter has only one value. If the parameter might have more
+     * than one value, use {@link #getParameterValues}.
      *
      * <p>
      * If you use this method with a multivalued parameter, the value returned is equal to the first value in the array
      * returned by <code>getParameterValues</code>.
      *
      * <p>
-     * If the parameter data was sent in the request body, such as occurs with an HTTP POST request, then reading the
-     * body directly via {@link #getInputStream} or {@link #getReader} can interfere with the execution of this method.
+     * If the parameter data was sent in the request body, such as occurs with an HTTP POST request, then reading the body
+     * directly via {@link #getInputStream} or {@link #getReader} can interfere with the execution of this method.
      *
      * @param name a <code>String</code> specifying the name of the parameter
      *
@@ -158,12 +156,11 @@ public interface ServletRequest {
 
     /**
      *
-     * Returns an <code>Enumeration</code> of <code>String</code> objects containing the names of the parameters
-     * contained in this request. If the request has no parameters, the method returns an empty
-     * <code>Enumeration</code>.
+     * Returns an <code>Enumeration</code> of <code>String</code> objects containing the names of the parameters contained
+     * in this request. If the request has no parameters, the method returns an empty <code>Enumeration</code>.
      *
-     * @return an <code>Enumeration</code> of <code>String</code> objects, each <code>String</code> containing the name
-     *         of a request parameter; or an empty <code>Enumeration</code> if the request has no parameters
+     * @return an <code>Enumeration</code> of <code>String</code> objects, each <code>String</code> containing the name of a
+     * request parameter; or an empty <code>Enumeration</code> if the request has no parameters
      */
     public Enumeration<String> getParameterNames();
 
@@ -186,18 +183,18 @@ public interface ServletRequest {
      * Returns a java.util.Map of the parameters of this request.
      * 
      * <p>
-     * Request parameters are extra information sent with the request. For HTTP servlets, parameters are contained in
-     * the query string or posted form data.
+     * Request parameters are extra information sent with the request. For HTTP servlets, parameters are contained in the
+     * query string or posted form data.
      *
-     * @return an immutable java.util.Map containing parameter names as keys and parameter values as map values. The
-     *         keys in the parameter map are of type String. The values in the parameter map are of type String array.
+     * @return an immutable java.util.Map containing parameter names as keys and parameter values as map values. The keys in
+     * the parameter map are of type String. The values in the parameter map are of type String array.
      */
     public Map<String, String[]> getParameterMap();
 
     /**
-     * Returns the name and version of the protocol the request uses in the form
-     * <i>protocol/majorVersion.minorVersion</i>, for example, HTTP/1.1. For HTTP servlets, the value returned is the
-     * same as the value of the CGI variable <code>SERVER_PROTOCOL</code>.
+     * Returns the name and version of the protocol the request uses in the form <i>protocol/majorVersion.minorVersion</i>,
+     * for example, HTTP/1.1. For HTTP servlets, the value returned is the same as the value of the CGI variable
+     * <code>SERVER_PROTOCOL</code>.
      *
      * @return a <code>String</code> containing the protocol name and version number
      */
@@ -220,34 +217,34 @@ public interface ServletRequest {
     public String getServerName();
 
     /**
-     * Returns the port number to which the request was sent. It is the value of the part after ":" in the
-     * <code>Host</code> header value, if any, or the server port where the client connection was accepted on.
+     * Returns the port number to which the request was sent. It is the value of the part after ":" in the <code>Host</code>
+     * header value, if any, or the server port where the client connection was accepted on.
      *
      * @return an integer specifying the port number
      */
     public int getServerPort();
 
     /**
-     * Retrieves the body of the request as character data using a <code>BufferedReader</code>. The reader translates
-     * the character data according to the character encoding used on the body. Either this method or
-     * {@link #getInputStream} may be called to read the body, not both.
+     * Retrieves the body of the request as character data using a <code>BufferedReader</code>. The reader translates the
+     * character data according to the character encoding used on the body. Either this method or {@link #getInputStream}
+     * may be called to read the body, not both.
      * 
      * @return a <code>BufferedReader</code> containing the body of the request
      *
-     * @exception UnsupportedEncodingException if the character set encoding used is not supported and the text cannot
-     *                                         be decoded
+     * @exception UnsupportedEncodingException if the character set encoding used is not supported and the text cannot be
+     * decoded
      *
-     * @exception IllegalStateException        if {@link #getInputStream} method has been called on this request
+     * @exception IllegalStateException if {@link #getInputStream} method has been called on this request
      *
-     * @exception IOException                  if an input or output exception occurred
+     * @exception IOException if an input or output exception occurred
      *
      * @see #getInputStream
      */
     public BufferedReader getReader() throws IOException;
 
     /**
-     * Returns the Internet Protocol (IP) address of the client or last proxy that sent the request. For HTTP servlets,
-     * same as the value of the CGI variable <code>REMOTE_ADDR</code>.
+     * Returns the Internet Protocol (IP) address of the client or last proxy that sent the request. For HTTP servlets, same
+     * as the value of the CGI variable <code>REMOTE_ADDR</code>.
      *
      * @return a <code>String</code> containing the IP address of the client that sent the request
      */
@@ -255,8 +252,8 @@ public interface ServletRequest {
 
     /**
      * Returns the fully qualified name of the client or the last proxy that sent the request. If the engine cannot or
-     * chooses not to resolve the hostname (to improve performance), this method returns the dotted-string form of the
-     * IP address. For HTTP servlets, same as the value of the CGI variable <code>REMOTE_HOST</code>.
+     * chooses not to resolve the hostname (to improve performance), this method returns the dotted-string form of the IP
+     * address. For HTTP servlets, same as the value of the CGI variable <code>REMOTE_HOST</code>.
      *
      * @return a <code>String</code> containing the fully qualified name of the client
      */
@@ -270,20 +267,19 @@ public interface ServletRequest {
      * Attribute names should follow the same conventions as package names. <br>
      * If the object passed in is null, the effect is the same as calling {@link #removeAttribute}. <br>
      * It is warned that when the request is dispatched from the servlet resides in a different web application by
-     * <code>RequestDispatcher</code>, the object set by this method may not be correctly retrieved in the caller
-     * servlet.
+     * <code>RequestDispatcher</code>, the object set by this method may not be correctly retrieved in the caller servlet.
      *
      * @param name a <code>String</code> specifying the name of the attribute
      *
-     * @param o    the <code>Object</code> to be stored
+     * @param o the <code>Object</code> to be stored
      *
      */
     public void setAttribute(String name, Object o);
 
     /**
      *
-     * Removes an attribute from this request. This method is not generally needed as attributes only persist as long as
-     * the request is being handled.
+     * Removes an attribute from this request. This method is not generally needed as attributes only persist as long as the
+     * request is being handled.
      *
      * <p>
      * Attribute names should follow the same conventions as package names. Names beginning with <code>java.*</code>,
@@ -295,18 +291,18 @@ public interface ServletRequest {
 
     /**
      * Returns the preferred <code>Locale</code> that the client will accept content in, based on the Accept-Language
-     * header. If the client request doesn't provide an Accept-Language header, this method returns the default locale
-     * for the server.
+     * header. If the client request doesn't provide an Accept-Language header, this method returns the default locale for
+     * the server.
      *
      * @return the preferred <code>Locale</code> for the client
      */
     public Locale getLocale();
 
     /**
-     * Returns an <code>Enumeration</code> of <code>Locale</code> objects indicating, in decreasing order starting with
-     * the preferred locale, the locales that are acceptable to the client based on the Accept-Language header. If the
-     * client request doesn't provide an Accept-Language header, this method returns an <code>Enumeration</code>
-     * containing one <code>Locale</code>, the default locale for the server.
+     * Returns an <code>Enumeration</code> of <code>Locale</code> objects indicating, in decreasing order starting with the
+     * preferred locale, the locales that are acceptable to the client based on the Accept-Language header. If the client
+     * request doesn't provide an Accept-Language header, this method returns an <code>Enumeration</code> containing one
+     * <code>Locale</code>, the default locale for the server.
      *
      * @return an <code>Enumeration</code> of preferred <code>Locale</code> objects for the client
      */
@@ -323,29 +319,29 @@ public interface ServletRequest {
     /**
      *
      * Returns a {@link RequestDispatcher} object that acts as a wrapper for the resource located at the given path. A
-     * <code>RequestDispatcher</code> object can be used to forward a request to the resource or to include the resource
-     * in a response. The resource can be dynamic or static.
+     * <code>RequestDispatcher</code> object can be used to forward a request to the resource or to include the resource in
+     * a response. The resource can be dynamic or static.
      *
      * <p>
-     * The pathname specified may be relative, although it cannot extend outside the current servlet context. If the
-     * path begins with a "/" it is interpreted as relative to the current context root. This method returns
-     * <code>null</code> if the servlet container cannot return a <code>RequestDispatcher</code>.
+     * The pathname specified may be relative, although it cannot extend outside the current servlet context. If the path
+     * begins with a "/" it is interpreted as relative to the current context root. This method returns <code>null</code> if
+     * the servlet container cannot return a <code>RequestDispatcher</code>.
      *
      * <p>
-     * Using a RequestDispatcher, requests may be dispatched to any part of the web application bypassing both implicit
-     * (no direct access to WEB-INF or META-INF) and explicit (defined by the web application) security constraints.
-     * Unsanitized user provided data must not be used to construct the path passed to the RequestDispatcher as it is
-     * very likely to create a security vulnerability in the application.
+     * Using a RequestDispatcher, requests may be dispatched to any part of the web application bypassing both implicit (no
+     * direct access to WEB-INF or META-INF) and explicit (defined by the web application) security constraints. Unsanitized
+     * user provided data must not be used to construct the path passed to the RequestDispatcher as it is very likely to
+     * create a security vulnerability in the application.
      *
      * <p>
      * The difference between this method and {@link ServletContext#getRequestDispatcher} is that this method can take a
      * relative path.
      *
      * @param path a <code>String</code> specifying the pathname to the resource. If it is relative, it must be relative
-     *             against the current servlet.
+     * against the current servlet.
      *
      * @return a <code>RequestDispatcher</code> object that acts as a wrapper for the resource at the specified path, or
-     *         <code>null</code> if the servlet container cannot return a <code>RequestDispatcher</code>
+     * <code>null</code> if the servlet container cannot return a <code>RequestDispatcher</code>
      *
      * @see RequestDispatcher
      * @see ServletContext#getRequestDispatcher
@@ -411,21 +407,20 @@ public interface ServletRequest {
      * ServletRequest and ServletResponse objects.
      *
      * <p>
-     * Calling this method will cause committal of the associated response to be delayed until
-     * {@link AsyncContext#complete} is called on the returned {@link AsyncContext}, or the asynchronous operation has
-     * timed out.
+     * Calling this method will cause committal of the associated response to be delayed until {@link AsyncContext#complete}
+     * is called on the returned {@link AsyncContext}, or the asynchronous operation has timed out.
      *
      * <p>
      * Calling {@link AsyncContext#hasOriginalRequestAndResponse()} on the returned AsyncContext will return
-     * <code>true</code>. Any filters invoked in the <i>outbound</i> direction after this request was put into
-     * asynchronous mode may use this as an indication that any request and/or response wrappers that they added during
-     * their <i>inbound</i> invocation need not stay around for the duration of the asynchronous operation, and
-     * therefore any of their associated resources may be released.
+     * <code>true</code>. Any filters invoked in the <i>outbound</i> direction after this request was put into asynchronous
+     * mode may use this as an indication that any request and/or response wrappers that they added during their
+     * <i>inbound</i> invocation need not stay around for the duration of the asynchronous operation, and therefore any of
+     * their associated resources may be released.
      *
      * <p>
-     * This method clears the list of {@link AsyncListener} instances (if any) that were registered with the
-     * AsyncContext returned by the previous call to one of the startAsync methods, after calling each AsyncListener at
-     * its {@link AsyncListener#onStartAsync onStartAsync} method.
+     * This method clears the list of {@link AsyncListener} instances (if any) that were registered with the AsyncContext
+     * returned by the previous call to one of the startAsync methods, after calling each AsyncListener at its
+     * {@link AsyncListener#onStartAsync onStartAsync} method.
      *
      * <p>
      * Subsequent invocations of this method, or its overloaded variant, will return the same AsyncContext instance,
@@ -434,11 +429,10 @@ public interface ServletRequest {
      * @return the (re)initialized AsyncContext
      * 
      * @throws IllegalStateException if this request is within the scope of a filter or servlet that does not support
-     *                               asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if
-     *                               this method is called again without any asynchronous dispatch (resulting from one
-     *                               of the {@link AsyncContext#dispatch} methods), is called outside the scope of any
-     *                               such dispatch, or is called again within the scope of the same dispatch, or if the
-     *                               response has already been closed
+     * asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if this method is called again without
+     * any asynchronous dispatch (resulting from one of the {@link AsyncContext#dispatch} methods), is called outside the
+     * scope of any such dispatch, or is called again within the scope of the same dispatch, or if the response has already
+     * been closed
      *
      * @see AsyncContext#dispatch()
      * @since Servlet 3.0
@@ -452,30 +446,29 @@ public interface ServletRequest {
      * <p>
      * The ServletRequest and ServletResponse arguments must be the same instances, or instances of
      * {@link ServletRequestWrapper} and {@link ServletResponseWrapper} that wrap them, that were passed to the
-     * {@link Servlet#service service} method of the Servlet or the {@link Filter#doFilter doFilter} method of the
-     * Filter, respectively, in whose scope this method is being called.
+     * {@link Servlet#service service} method of the Servlet or the {@link Filter#doFilter doFilter} method of the Filter,
+     * respectively, in whose scope this method is being called.
      *
      * <p>
-     * Calling this method will cause committal of the associated response to be delayed until
-     * {@link AsyncContext#complete} is called on the returned {@link AsyncContext}, or the asynchronous operation has
-     * timed out.
+     * Calling this method will cause committal of the associated response to be delayed until {@link AsyncContext#complete}
+     * is called on the returned {@link AsyncContext}, or the asynchronous operation has timed out.
      *
      * <p>
      * Calling {@link AsyncContext#hasOriginalRequestAndResponse()} on the returned AsyncContext will return
-     * <code>false</code>, unless the passed in ServletRequest and ServletResponse arguments are the original ones or do
-     * not carry any application-provided wrappers. Any filters invoked in the <i>outbound</i> direction after this
-     * request was put into asynchronous mode may use this as an indication that some of the request and/or response
-     * wrappers that they added during their <i>inbound</i> invocation may need to stay in place for the duration of the
-     * asynchronous operation, and their associated resources may not be released. A ServletRequestWrapper applied
-     * during the <i>inbound</i> invocation of a filter may be released by the <i>outbound</i> invocation of the filter
-     * only if the given <code>servletRequest</code>, which is used to initialize the AsyncContext and will be returned
-     * by a call to {@link AsyncContext#getRequest()}, does not contain said ServletRequestWrapper. The same holds true
-     * for ServletResponseWrapper instances.
+     * <code>false</code>, unless the passed in ServletRequest and ServletResponse arguments are the original ones or do not
+     * carry any application-provided wrappers. Any filters invoked in the <i>outbound</i> direction after this request was
+     * put into asynchronous mode may use this as an indication that some of the request and/or response wrappers that they
+     * added during their <i>inbound</i> invocation may need to stay in place for the duration of the asynchronous
+     * operation, and their associated resources may not be released. A ServletRequestWrapper applied during the
+     * <i>inbound</i> invocation of a filter may be released by the <i>outbound</i> invocation of the filter only if the
+     * given <code>servletRequest</code>, which is used to initialize the AsyncContext and will be returned by a call to
+     * {@link AsyncContext#getRequest()}, does not contain said ServletRequestWrapper. The same holds true for
+     * ServletResponseWrapper instances.
      *
      * <p>
-     * This method clears the list of {@link AsyncListener} instances (if any) that were registered with the
-     * AsyncContext returned by the previous call to one of the startAsync methods, after calling each AsyncListener at
-     * its {@link AsyncListener#onStartAsync onStartAsync} method.
+     * This method clears the list of {@link AsyncListener} instances (if any) that were registered with the AsyncContext
+     * returned by the previous call to one of the startAsync methods, after calling each AsyncListener at its
+     * {@link AsyncListener#onStartAsync onStartAsync} method.
      *
      * <p>
      * Subsequent invocations of this method, or its zero-argument variant, will return the same AsyncContext instance,
@@ -483,17 +476,16 @@ public interface ServletRequest {
      * specified (and possibly wrapped) request and response objects will remain <i>locked in</i> on the returned
      * AsyncContext.
      *
-     * @param servletRequest  the ServletRequest used to initialize the AsyncContext
+     * @param servletRequest the ServletRequest used to initialize the AsyncContext
      * @param servletResponse the ServletResponse used to initialize the AsyncContext
      *
      * @return the (re)initialized AsyncContext
      * 
      * @throws IllegalStateException if this request is within the scope of a filter or servlet that does not support
-     *                               asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if
-     *                               this method is called again without any asynchronous dispatch (resulting from one
-     *                               of the {@link AsyncContext#dispatch} methods), is called outside the scope of any
-     *                               such dispatch, or is called again within the scope of the same dispatch, or if the
-     *                               response has already been closed
+     * asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if this method is called again without
+     * any asynchronous dispatch (resulting from one of the {@link AsyncContext#dispatch} methods), is called outside the
+     * scope of any such dispatch, or is called again within the scope of the same dispatch, or if the response has already
+     * been closed
      *
      * @since Servlet 3.0
      */
@@ -522,9 +514,8 @@ public interface ServletRequest {
      * Checks if this request supports asynchronous operation.
      *
      * <p>
-     * Asynchronous operation is disabled for this request if this request is within the scope of a filter or servlet
-     * that has not been annotated or flagged in the deployment descriptor as being able to support asynchronous
-     * handling.
+     * Asynchronous operation is disabled for this request if this request is within the scope of a filter or servlet that
+     * has not been annotated or flagged in the deployment descriptor as being able to support asynchronous handling.
      *
      * @return true if this request supports asynchronous operation, false otherwise
      *
@@ -536,12 +527,11 @@ public interface ServletRequest {
      * Gets the AsyncContext that was created or reinitialized by the most recent invocation of {@link #startAsync} or
      * {@link #startAsync(ServletRequest,ServletResponse)} on this request.
      *
-     * @return the AsyncContext that was created or reinitialized by the most recent invocation of {@link #startAsync}
-     *         or {@link #startAsync(ServletRequest,ServletResponse)} on this request
+     * @return the AsyncContext that was created or reinitialized by the most recent invocation of {@link #startAsync} or
+     * {@link #startAsync(ServletRequest,ServletResponse)} on this request
      *
      * @throws IllegalStateException if this request has not been put into asynchronous mode, i.e., if neither
-     *                               {@link #startAsync} nor {@link #startAsync(ServletRequest,ServletResponse)} has
-     *                               been called
+     * {@link #startAsync} nor {@link #startAsync(ServletRequest,ServletResponse)} has been called
      *
      * @since Servlet 3.0
      */
@@ -555,17 +545,17 @@ public interface ServletRequest {
      * request: Only filters with matching dispatcher type and url patterns will be applied.
      * 
      * <p>
-     * Allowing a filter that has been configured for multiple dispatcher types to query a request for its dispatcher
-     * type allows the filter to process the request differently depending on its dispatcher type.
+     * Allowing a filter that has been configured for multiple dispatcher types to query a request for its dispatcher type
+     * allows the filter to process the request differently depending on its dispatcher type.
      *
      * <p>
-     * The initial dispatcher type of a request is defined as <code>DispatcherType.REQUEST</code>. The dispatcher type
-     * of a request dispatched via {@link RequestDispatcher#forward(ServletRequest, ServletResponse)} or
-     * {@link RequestDispatcher#include(ServletRequest, ServletResponse)} is given as
-     * <code>DispatcherType.FORWARD</code> or <code>DispatcherType.INCLUDE</code>, respectively, while the dispatcher
-     * type of an asynchronous request dispatched via one of the {@link AsyncContext#dispatch} methods is given as
-     * <code>DispatcherType.ASYNC</code>. Finally, the dispatcher type of a request dispatched to an error page by the
-     * container's error handling mechanism is given as <code>DispatcherType.ERROR</code>.
+     * The initial dispatcher type of a request is defined as <code>DispatcherType.REQUEST</code>. The dispatcher type of a
+     * request dispatched via {@link RequestDispatcher#forward(ServletRequest, ServletResponse)} or
+     * {@link RequestDispatcher#include(ServletRequest, ServletResponse)} is given as <code>DispatcherType.FORWARD</code> or
+     * <code>DispatcherType.INCLUDE</code>, respectively, while the dispatcher type of an asynchronous request dispatched
+     * via one of the {@link AsyncContext#dispatch} methods is given as <code>DispatcherType.ASYNC</code>. Finally, the
+     * dispatcher type of a request dispatched to an error page by the container's error handling mechanism is given as
+     * <code>DispatcherType.ERROR</code>.
      *
      * @return the dispatcher type of this request
      * 

--- a/api/src/main/java/jakarta/servlet/ServletRequestAttributeEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestAttributeEvent.java
@@ -32,13 +32,13 @@ public class ServletRequestAttributeEvent extends ServletRequestEvent {
     private Object value;
 
     /**
-     * Construct a ServletRequestAttributeEvent giving the servlet context of this web application, the ServletRequest
-     * whose attributes are changing and the name and value of the attribute.
+     * Construct a ServletRequestAttributeEvent giving the servlet context of this web application, the ServletRequest whose
+     * attributes are changing and the name and value of the attribute.
      *
-     * @param sc      the ServletContext that is sending the event.
+     * @param sc the ServletContext that is sending the event.
      * @param request the ServletRequest that is sending the event.
-     * @param name    the name of the request attribute.
-     * @param value   the value of the request attribute.
+     * @param name the name of the request attribute.
+     * @param value the value of the request attribute.
      */
     public ServletRequestAttributeEvent(ServletContext sc, ServletRequest request, String name, Object value) {
         super(sc, request);
@@ -56,9 +56,9 @@ public class ServletRequestAttributeEvent extends ServletRequestEvent {
     }
 
     /**
-     * Returns the value of the attribute that has been added, removed or replaced. If the attribute was added, this is
-     * the value of the attribute. If the attribute was removed, this is the value of the removed attribute. If the
-     * attribute was replaced, this is the old value of the attribute.
+     * Returns the value of the attribute that has been added, removed or replaced. If the attribute was added, this is the
+     * value of the attribute. If the attribute was removed, this is the value of the removed attribute. If the attribute
+     * was replaced, this is the old value of the attribute.
      *
      * @return the value of the changed request attribute
      */

--- a/api/src/main/java/jakarta/servlet/ServletRequestAttributeListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestAttributeListener.java
@@ -30,8 +30,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link ServletContext}.
  *
  * <p>
  * The order in which implementations of this interface are invoked is unspecified.
@@ -43,8 +43,8 @@ public interface ServletRequestAttributeListener extends EventListener {
     /**
      * Receives notification that an attribute has been added to the ServletRequest.
      *
-     * @param srae the ServletRequestAttributeEvent containing the ServletRequest and the name and value of the
-     *             attribute that was added
+     * @param srae the ServletRequestAttributeEvent containing the ServletRequest and the name and value of the attribute
+     * that was added
      *
      * @implSpec The default implementation takes no action.
      */
@@ -54,8 +54,8 @@ public interface ServletRequestAttributeListener extends EventListener {
     /**
      * Receives notification that an attribute has been removed from the ServletRequest.
      *
-     * @param srae the ServletRequestAttributeEvent containing the ServletRequest and the name and value of the
-     *             attribute that was removed
+     * @param srae the ServletRequestAttributeEvent containing the ServletRequest and the name and value of the attribute
+     * that was removed
      *
      * @implSpec The default implementation takes no action.
      */
@@ -66,7 +66,7 @@ public interface ServletRequestAttributeListener extends EventListener {
      * Receives notification that an attribute has been replaced on the ServletRequest.
      *
      * @param srae the ServletRequestAttributeEvent containing the ServletRequest and the name and (old) value of the
-     *             attribute that was replaced
+     * attribute that was replaced
      *
      * @implSpec The default implementation takes no action.
      */

--- a/api/src/main/java/jakarta/servlet/ServletRequestEvent.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestEvent.java
@@ -34,7 +34,7 @@ public class ServletRequestEvent extends java.util.EventObject {
     /**
      * Construct a ServletRequestEvent for the given ServletContext and ServletRequest.
      *
-     * @param sc      the ServletContext of the web application.
+     * @param sc the ServletContext of the web application.
      * @param request the ServletRequest that is sending the event.
      */
     public ServletRequestEvent(ServletContext sc, ServletRequest request) {

--- a/api/src/main/java/jakarta/servlet/ServletRequestListener.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestListener.java
@@ -30,8 +30,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link ServletContext}.
  *
  * <p>
  * Implementations of this interface are invoked at their {@link #requestInitialized} method in the order in which they
@@ -45,7 +45,7 @@ public interface ServletRequestListener extends EventListener {
      * Receives notification that a ServletRequest is about to go out of scope of the web application.
      *
      * @param sre the ServletRequestEvent containing the ServletRequest and the ServletContext representing the web
-     *            application
+     * application
      *
      * @implSpec The default implementation takes no action.
      */
@@ -56,7 +56,7 @@ public interface ServletRequestListener extends EventListener {
      * Receives notification that a ServletRequest is about to come into scope of the web application.
      *
      * @param sre the ServletRequestEvent containing the ServletRequest and the ServletContext representing the web
-     *            application
+     * application
      *
      * @implSpec The default implementation takes no action.
      */

--- a/api/src/main/java/jakarta/servlet/ServletRequestWrapper.java
+++ b/api/src/main/java/jakarta/servlet/ServletRequestWrapper.java
@@ -231,8 +231,7 @@ public class ServletRequestWrapper implements ServletRequest {
     }
 
     /**
-     * The default behavior of this method is to return setAttribute(String name, Object o) on the wrapped request
-     * object.
+     * The default behavior of this method is to return setAttribute(String name, Object o) on the wrapped request object.
      */
     @Override
     public void setAttribute(String name, Object o) {
@@ -348,11 +347,10 @@ public class ServletRequestWrapper implements ServletRequest {
      * @return the (re)initialized AsyncContext
      * 
      * @throws IllegalStateException if the request is within the scope of a filter or servlet that does not support
-     *                               asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if
-     *                               this method is called again without any asynchronous dispatch (resulting from one
-     *                               of the {@link AsyncContext#dispatch} methods), is called outside the scope of any
-     *                               such dispatch, or is called again within the scope of the same dispatch, or if the
-     *                               response has already been closed
+     * asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if this method is called again without
+     * any asynchronous dispatch (resulting from one of the {@link AsyncContext#dispatch} methods), is called outside the
+     * scope of any such dispatch, or is called again within the scope of the same dispatch, or if the response has already
+     * been closed
      *
      * @see ServletRequest#startAsync
      *
@@ -364,20 +362,19 @@ public class ServletRequestWrapper implements ServletRequest {
     }
 
     /**
-     * The default behavior of this method is to invoke
-     * {@link ServletRequest#startAsync(ServletRequest, ServletResponse)} on the wrapped request object.
+     * The default behavior of this method is to invoke {@link ServletRequest#startAsync(ServletRequest, ServletResponse)}
+     * on the wrapped request object.
      *
-     * @param servletRequest  the ServletRequest used to initialize the AsyncContext
+     * @param servletRequest the ServletRequest used to initialize the AsyncContext
      * @param servletResponse the ServletResponse used to initialize the AsyncContext
      *
      * @return the (re)initialized AsyncContext
      *
      * @throws IllegalStateException if the request is within the scope of a filter or servlet that does not support
-     *                               asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if
-     *                               this method is called again without any asynchronous dispatch (resulting from one
-     *                               of the {@link AsyncContext#dispatch} methods), is called outside the scope of any
-     *                               such dispatch, or is called again within the scope of the same dispatch, or if the
-     *                               response has already been closed
+     * asynchronous operations (that is, {@link #isAsyncSupported} returns false), or if this method is called again without
+     * any asynchronous dispatch (resulting from one of the {@link AsyncContext#dispatch} methods), is called outside the
+     * scope of any such dispatch, or is called again within the scope of the same dispatch, or if the response has already
+     * been closed
      *
      * @see ServletRequest#startAsync(ServletRequest, ServletResponse)
      *
@@ -421,12 +418,11 @@ public class ServletRequestWrapper implements ServletRequest {
      * Gets the AsyncContext that was created or reinitialized by the most recent invocation of {@link #startAsync} or
      * {@link #startAsync(ServletRequest,ServletResponse)} on the wrapped request.
      *
-     * @return the AsyncContext that was created or reinitialized by the most recent invocation of {@link #startAsync}
-     *         or {@link #startAsync(ServletRequest,ServletResponse)} on the wrapped request
+     * @return the AsyncContext that was created or reinitialized by the most recent invocation of {@link #startAsync} or
+     * {@link #startAsync(ServletRequest,ServletResponse)} on the wrapped request
      *
      * @throws IllegalStateException if this request has not been put into asynchronous mode, i.e., if neither
-     *                               {@link #startAsync} nor {@link #startAsync(ServletRequest,ServletResponse)} has
-     *                               been called
+     * {@link #startAsync} nor {@link #startAsync(ServletRequest,ServletResponse)} has been called
      *
      * @see ServletRequest#getAsyncContext
      *

--- a/api/src/main/java/jakarta/servlet/ServletResponse.java
+++ b/api/src/main/java/jakarta/servlet/ServletResponse.java
@@ -55,15 +55,14 @@ public interface ServletResponse {
 
     /**
      * Returns the name of the character encoding (MIME charset) used for the body sent in this response. The following
-     * methods for specifying the response character encoding are consulted, in decreasing order of priority: per
-     * request, perweb-app (using {@link ServletContext#setResponseCharacterEncoding}, deployment descriptor), and per
-     * container (for all web applications deployed in that container, using vendor specific configuration). The first
-     * one of these methods that yields a result is returned. Per-request, the charset for the response can be specified
-     * explicitly using the {@link #setCharacterEncoding} and {@link #setContentType} methods, or implicitly using the
-     * setLocale(java.util.Locale) method. Explicit specifications take precedence over implicit specifications. Calls
-     * made to these methods after <code>getWriter</code> has been called or after the response has been committed have
-     * no effect on the character encoding. If no character encoding has been specified, <code>ISO-8859-1</code> is
-     * returned.
+     * methods for specifying the response character encoding are consulted, in decreasing order of priority: per request,
+     * perweb-app (using {@link ServletContext#setResponseCharacterEncoding}, deployment descriptor), and per container (for
+     * all web applications deployed in that container, using vendor specific configuration). The first one of these methods
+     * that yields a result is returned. Per-request, the charset for the response can be specified explicitly using the
+     * {@link #setCharacterEncoding} and {@link #setContentType} methods, or implicitly using the
+     * setLocale(java.util.Locale) method. Explicit specifications take precedence over implicit specifications. Calls made
+     * to these methods after <code>getWriter</code> has been called or after the response has been committed have no effect
+     * on the character encoding. If no character encoding has been specified, <code>ISO-8859-1</code> is returned.
      * <p>
      * See RFC 2047 (http://www.ietf.org/rfc/rfc2047.txt) for more information about character encoding and MIME.
      *
@@ -73,34 +72,33 @@ public interface ServletResponse {
 
     /**
      * Returns the content type used for the MIME body sent in this response. The content type proper must have been
-     * specified using {@link #setContentType} before the response is committed. If no content type has been specified,
-     * this method returns null. If a content type has been specified, and a character encoding has been explicitly or
-     * implicitly specified as described in {@link #getCharacterEncoding} or {@link #getWriter} has been called, the
-     * charset parameter is included in the string returned. If no character encoding has been specified, the charset
-     * parameter is omitted.
+     * specified using {@link #setContentType} before the response is committed. If no content type has been specified, this
+     * method returns null. If a content type has been specified, and a character encoding has been explicitly or implicitly
+     * specified as described in {@link #getCharacterEncoding} or {@link #getWriter} has been called, the charset parameter
+     * is included in the string returned. If no character encoding has been specified, the charset parameter is omitted.
      *
      * @return a <code>String</code> specifying the content type, for example, <code>text/html; charset=UTF-8</code>, or
-     *         null
+     * null
      *
      * @since Servlet 2.4
      */
     public String getContentType();
 
     /**
-     * Returns a {@link ServletOutputStream} suitable for writing binary data in the response. The servlet container
-     * does not encode the binary data.
+     * Returns a {@link ServletOutputStream} suitable for writing binary data in the response. The servlet container does
+     * not encode the binary data.
      *
      * <p>
      * Calling flush() on the ServletOutputStream commits the response.
      *
-     * Either this method or {@link #getWriter} may be called to write the body, not both, except when {@link #reset}
-     * has been called.
+     * Either this method or {@link #getWriter} may be called to write the body, not both, except when {@link #reset} has
+     * been called.
      *
      * @return a {@link ServletOutputStream} for writing binary data
      *
      * @exception IllegalStateException if the <code>getWriter</code> method has been called on this response
      *
-     * @exception IOException           if an input or output exception occurred
+     * @exception IOException if an input or output exception occurred
      *
      * @see #getWriter
      * @see #reset
@@ -108,26 +106,25 @@ public interface ServletResponse {
     public ServletOutputStream getOutputStream() throws IOException;
 
     /**
-     * Returns a <code>PrintWriter</code> object that can send character text to the client. The
-     * <code>PrintWriter</code> uses the character encoding returned by {@link #getCharacterEncoding}. If the response's
-     * character encoding has not been specified as described in <code>getCharacterEncoding</code> (i.e., the method
-     * just returns the default value <code>ISO-8859-1</code>), <code>getWriter</code> updates it to
-     * <code>ISO-8859-1</code>.
+     * Returns a <code>PrintWriter</code> object that can send character text to the client. The <code>PrintWriter</code>
+     * uses the character encoding returned by {@link #getCharacterEncoding}. If the response's character encoding has not
+     * been specified as described in <code>getCharacterEncoding</code> (i.e., the method just returns the default value
+     * <code>ISO-8859-1</code>), <code>getWriter</code> updates it to <code>ISO-8859-1</code>.
      * <p>
      * Calling flush() on the <code>PrintWriter</code> commits the response.
      * <p>
-     * Either this method or {@link #getOutputStream} may be called to write the body, not both, except when
-     * {@link #reset} has been called.
+     * Either this method or {@link #getOutputStream} may be called to write the body, not both, except when {@link #reset}
+     * has been called.
      * 
      * @return a <code>PrintWriter</code> object that can return character data to the client
      *
-     * @exception                       java.io.UnsupportedEncodingException if the character encoding returned by
-     *                                  <code>getCharacterEncoding</code> cannot be used
+     * @exception java.io.UnsupportedEncodingException if the character encoding returned by
+     * <code>getCharacterEncoding</code> cannot be used
      *
-     * @exception IllegalStateException if the <code>getOutputStream</code> method has already been called for this
-     *                                  response object
+     * @exception IllegalStateException if the <code>getOutputStream</code> method has already been called for this response
+     * object
      *
-     * @exception IOException           if an input or output exception occurred
+     * @exception IOException if an input or output exception occurred
      *
      * @see #getOutputStream
      * @see #setCharacterEncoding
@@ -136,24 +133,24 @@ public interface ServletResponse {
     public PrintWriter getWriter() throws IOException;
 
     /**
-     * Sets the character encoding (MIME charset) of the response being sent to the client, for example, to UTF-8. If
-     * the response character encoding has already been set by the {@link ServletContext#setResponseCharacterEncoding},
-     * deployment descriptor, or using the setContentType() or setLocale() methods, the value set in this method
-     * overrides any of those values. Calling {@link #setContentType} with the <code>String</code> of
-     * <code>text/html</code> and calling this method with the <code>String</code> of <code>UTF-8</code> is equivalent
-     * with calling <code>setContentType</code> with the <code>String</code> of <code>text/html; charset=UTF-8</code>.
+     * Sets the character encoding (MIME charset) of the response being sent to the client, for example, to UTF-8. If the
+     * response character encoding has already been set by the {@link ServletContext#setResponseCharacterEncoding},
+     * deployment descriptor, or using the setContentType() or setLocale() methods, the value set in this method overrides
+     * any of those values. Calling {@link #setContentType} with the <code>String</code> of <code>text/html</code> and
+     * calling this method with the <code>String</code> of <code>UTF-8</code> is equivalent with calling
+     * <code>setContentType</code> with the <code>String</code> of <code>text/html; charset=UTF-8</code>.
      * <p>
      * This method can be called repeatedly to change the character encoding. This method has no effect if it is called
      * after <code>getWriter</code> has been called or after the response has been committed.
      * <p>
      * Containers must communicate the character encoding used for the servlet response's writer to the client if the
      * protocol provides a way for doing so. In the case of HTTP, the character encoding is communicated as part of the
-     * <code>Content-Type</code> header for text media types. Note that the character encoding cannot be communicated
-     * via HTTP headers if the servlet does not specify a content type; however, it is still used to encode text written
-     * via the servlet response's writer.
+     * <code>Content-Type</code> header for text media types. Note that the character encoding cannot be communicated via
+     * HTTP headers if the servlet does not specify a content type; however, it is still used to encode text written via the
+     * servlet response's writer.
      *
      * @param charset a String specifying only the character set defined by IANA Character Sets
-     *                (http://www.iana.org/assignments/character-sets)
+     * (http://www.iana.org/assignments/character-sets)
      *
      * @see #setContentType
      * @see #setLocale
@@ -167,7 +164,7 @@ public interface ServletResponse {
      * header.
      *
      * @param len an integer specifying the length of the content being returned to the client; sets the Content-Length
-     *            header
+     * header
      */
     public void setContentLength(int len);
 
@@ -175,26 +172,25 @@ public interface ServletResponse {
      * Sets the length of the content body in the response In HTTP servlets, this method sets the HTTP Content-Length
      * header.
      *
-     * @param len a long specifying the length of the content being returned to the client; sets the Content-Length
-     *            header
+     * @param len a long specifying the length of the content being returned to the client; sets the Content-Length header
      *
      * @since Servlet 3.1
      */
     public void setContentLengthLong(long len);
 
     /**
-     * Sets the content type of the response being sent to the client, if the response has not been committed yet. The
-     * given content type may include a character encoding specification, for example,
-     * <code>text/html;charset=UTF-8</code>. The response's character encoding is only set from the given content type
-     * if this method is called before <code>getWriter</code> is called.
+     * Sets the content type of the response being sent to the client, if the response has not been committed yet. The given
+     * content type may include a character encoding specification, for example, <code>text/html;charset=UTF-8</code>. The
+     * response's character encoding is only set from the given content type if this method is called before
+     * <code>getWriter</code> is called.
      * <p>
      * This method may be called repeatedly to change content type and character encoding. This method has no effect if
-     * called after the response has been committed. It does not set the response's character encoding if it is called
-     * after <code>getWriter</code> has been called or after the response has been committed.
+     * called after the response has been committed. It does not set the response's character encoding if it is called after
+     * <code>getWriter</code> has been called or after the response has been committed.
      * <p>
-     * Containers must communicate the content type and the character encoding used for the servlet response's writer to
-     * the client if the protocol provides a way for doing so. In the case of HTTP, the <code>Content-Type</code> header
-     * is used.
+     * Containers must communicate the content type and the character encoding used for the servlet response's writer to the
+     * client if the protocol provides a way for doing so. In the case of HTTP, the <code>Content-Type</code> header is
+     * used.
      *
      * @param type a <code>String</code> specifying the MIME type of the content
      *
@@ -211,13 +207,13 @@ public interface ServletResponse {
      * large as the size requested. The actual buffer size used can be found using <code>getBufferSize</code>.
      *
      * <p>
-     * A larger buffer allows more content to be written before anything is actually sent, thus providing the servlet
-     * with more time to set appropriate status codes and headers. A smaller buffer decreases server memory load and
-     * allows the client to start receiving data more quickly.
+     * A larger buffer allows more content to be written before anything is actually sent, thus providing the servlet with
+     * more time to set appropriate status codes and headers. A smaller buffer decreases server memory load and allows the
+     * client to start receiving data more quickly.
      *
      * <p>
-     * This method must be called before any response body content is written; if content has been written or the
-     * response object has been committed, this method throws an <code>IllegalStateException</code>.
+     * This method must be called before any response body content is written; if content has been written or the response
+     * object has been committed, this method throws an <code>IllegalStateException</code>.
      *
      * @param size the preferred buffer size
      *
@@ -257,8 +253,8 @@ public interface ServletResponse {
     public void flushBuffer() throws IOException;
 
     /**
-     * Clears the content of the underlying buffer in the response without clearing headers or status code. If the
-     * response has been committed, this method throws an <code>IllegalStateException</code>.
+     * Clears the content of the underlying buffer in the response without clearing headers or status code. If the response
+     * has been committed, this method throws an <code>IllegalStateException</code>.
      *
      * @see #setBufferSize
      * @see #getBufferSize
@@ -270,8 +266,8 @@ public interface ServletResponse {
     public void resetBuffer();
 
     /**
-     * Returns a boolean indicating if the response has been committed. A committed response has already had its status
-     * code and headers written.
+     * Returns a boolean indicating if the response has been committed. A committed response has already had its status code
+     * and headers written.
      *
      * @return a boolean indicating if the response has been committed
      *
@@ -287,9 +283,9 @@ public interface ServletResponse {
      * Clears any data that exists in the buffer as well as the status code, headers. The state of calling
      * {@link #getWriter} or {@link #getOutputStream} is also cleared. It is legal, for instance, to call
      * {@link #getWriter}, {@link #reset} and then {@link #getOutputStream}. If {@link #getWriter} or
-     * {@link #getOutputStream} have been called before this method, then the corrresponding returned Writer or
-     * OutputStream will be staled and the behavior of using the stale object is undefined. If the response has been
-     * committed, this method throws an <code>IllegalStateException</code>.
+     * {@link #getOutputStream} have been called before this method, then the corrresponding returned Writer or OutputStream
+     * will be staled and the behavior of using the stale object is undefined. If the response has been committed, this
+     * method throws an <code>IllegalStateException</code>.
      *
      * @exception IllegalStateException if the response has already been committed
      *
@@ -301,23 +297,23 @@ public interface ServletResponse {
     public void reset();
 
     /**
-     * Sets the locale of the response, if the response has not been committed yet. It also sets the response's
-     * character encoding appropriately for the locale, if the character encoding has not been explicitly set using
+     * Sets the locale of the response, if the response has not been committed yet. It also sets the response's character
+     * encoding appropriately for the locale, if the character encoding has not been explicitly set using
      * {@link #setContentType} or {@link #setCharacterEncoding}, <code>getWriter</code> hasn't been called yet, and the
-     * response hasn't been committed yet. If the deployment descriptor contains a
-     * <code>locale-encoding-mapping-list</code> element, and that element provides a mapping for the given locale, that
-     * mapping is used. Otherwise, the mapping from locale to character encoding is container dependent.
+     * response hasn't been committed yet. If the deployment descriptor contains a <code>locale-encoding-mapping-list</code>
+     * element, and that element provides a mapping for the given locale, that mapping is used. Otherwise, the mapping from
+     * locale to character encoding is container dependent.
      * <p>
      * This method may be called repeatedly to change locale and character encoding. The method has no effect if called
      * after the response has been committed. It does not set the response's character encoding if it is called after
-     * {@link #setContentType} has been called with a charset specification, after {@link #setCharacterEncoding} has
-     * been called, after <code>getWriter</code> has been called, or after the response has been committed.
+     * {@link #setContentType} has been called with a charset specification, after {@link #setCharacterEncoding} has been
+     * called, after <code>getWriter</code> has been called, or after the response has been committed.
      * <p>
      * Containers must communicate the locale and the character encoding used for the servlet response's writer to the
      * client if the protocol provides a way for doing so. In the case of HTTP, the locale is communicated via the
-     * <code>Content-Language</code> header, the character encoding as part of the <code>Content-Type</code> header for
-     * text media types. Note that the character encoding cannot be communicated via HTTP headers if the servlet does
-     * not specify a content type; however, it is still used to encode text written via the servlet response's writer.
+     * <code>Content-Language</code> header, the character encoding as part of the <code>Content-Type</code> header for text
+     * media types. Note that the character encoding cannot be communicated via HTTP headers if the servlet does not specify
+     * a content type; however, it is still used to encode text written via the servlet response's writer.
      * 
      * @param loc the locale of the response
      *

--- a/api/src/main/java/jakarta/servlet/ServletResponseWrapper.java
+++ b/api/src/main/java/jakarta/servlet/ServletResponseWrapper.java
@@ -74,8 +74,7 @@ public class ServletResponseWrapper implements ServletResponse {
     }
 
     /**
-     * The default behavior of this method is to call setCharacterEncoding(String charset) on the wrapped response
-     * object.
+     * The default behavior of this method is to call setCharacterEncoding(String charset) on the wrapped response object.
      *
      * @since Servlet 2.4
      */

--- a/api/src/main/java/jakarta/servlet/ServletSecurityElement.java
+++ b/api/src/main/java/jakarta/servlet/ServletSecurityElement.java
@@ -17,9 +17,9 @@
 
 package jakarta.servlet;
 
-import java.util.*;
 import jakarta.servlet.annotation.HttpMethodConstraint;
 import jakarta.servlet.annotation.ServletSecurity;
+import java.util.*;
 
 /**
  * Java Class representation of a {@link ServletSecurity} annotation value.
@@ -32,8 +32,8 @@ public class ServletSecurityElement extends HttpConstraintElement {
     private Collection<HttpMethodConstraintElement> methodConstraints;
 
     /**
-     * Constructs an instance using the default <code>HttpConstraintElement</code> value as the default Constraint
-     * element and with no HTTP Method specific constraint elements.
+     * Constructs an instance using the default <code>HttpConstraintElement</code> value as the default Constraint element
+     * and with no HTTP Method specific constraint elements.
      */
     public ServletSecurityElement() {
         methodConstraints = new HashSet<>();
@@ -44,7 +44,7 @@ public class ServletSecurityElement extends HttpConstraintElement {
      * Constructs an instance with a default Constraint element and with no HTTP Method specific constraint elements.
      *
      * @param constraint the HttpConstraintElement to be applied to all HTTP methods other than those represented in the
-     *                   <tt>methodConstraints</tt>
+     * <tt>methodConstraints</tt>
      */
     public ServletSecurityElement(HttpConstraintElement constraint) {
         super(constraint.getEmptyRoleSemantic(), constraint.getTransportGuarantee(), constraint.getRolesAllowed());
@@ -53,8 +53,8 @@ public class ServletSecurityElement extends HttpConstraintElement {
     }
 
     /**
-     * Constructs an instance using the default <code>HttpConstraintElement</code> value as the default Constraint
-     * element and with a collection of HTTP Method specific constraint elements.
+     * Constructs an instance using the default <code>HttpConstraintElement</code> value as the default Constraint element
+     * and with a collection of HTTP Method specific constraint elements.
      *
      * @param methodConstraints the collection of HTTP method specific constraint elements
      *
@@ -69,8 +69,8 @@ public class ServletSecurityElement extends HttpConstraintElement {
      * Constructs an instance with a default Constraint element and with a collection of HTTP Method specific constraint
      * elements.
      *
-     * @param constraint        the HttpConstraintElement to be applied to all HTTP methods other than those represented
-     *                          in the <tt>methodConstraints</tt>
+     * @param constraint the HttpConstraintElement to be applied to all HTTP methods other than those represented in the
+     * <tt>methodConstraints</tt>
      * @param methodConstraints the collection of HTTP method specific constraint elements.
      *
      * @throws IllegalArgumentException if duplicate method names are detected

--- a/api/src/main/java/jakarta/servlet/SessionCookieConfig.java
+++ b/api/src/main/java/jakarta/servlet/SessionCookieConfig.java
@@ -28,24 +28,24 @@ package jakarta.servlet;
 public interface SessionCookieConfig {
 
     /**
-     * Sets the name that will be assigned to any session tracking cookies created on behalf of the application
-     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * Sets the name that will be assigned to any session tracking cookies created on behalf of the application represented
+     * by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * <p>
-     * NOTE: Changing the name of session tracking cookies may break other tiers (for example, a load balancing
-     * frontend) that assume the cookie name to be equal to the default <tt>JSESSIONID</tt>, and therefore should only
-     * be done cautiously.
+     * NOTE: Changing the name of session tracking cookies may break other tiers (for example, a load balancing frontend)
+     * that assume the cookie name to be equal to the default <tt>JSESSIONID</tt>, and therefore should only be done
+     * cautiously.
      *
      * @param name the cookie name to use
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      */
     public void setName(String name);
 
     /**
-     * Gets the name that will be assigned to any session tracking cookies created on behalf of the application
-     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * Gets the name that will be assigned to any session tracking cookies created on behalf of the application represented
+     * by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * <p>
      * By default, <tt>JSESSIONID</tt> will be used as the cookie name.
@@ -63,7 +63,7 @@ public interface SessionCookieConfig {
      * @param domain the cookie domain to use
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setDomain(String)
      */
@@ -80,25 +80,25 @@ public interface SessionCookieConfig {
     public String getDomain();
 
     /**
-     * Sets the path that will be assigned to any session tracking cookies created on behalf of the application
-     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * Sets the path that will be assigned to any session tracking cookies created on behalf of the application represented
+     * by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * @param path the cookie path to use
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setPath(String)
      */
     public void setPath(String path);
 
     /**
-     * Gets the path that will be assigned to any session tracking cookies created on behalf of the application
-     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * Gets the path that will be assigned to any session tracking cookies created on behalf of the application represented
+     * by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * <p>
-     * By default, the context path of the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     * acquired will be used.
+     * By default, the context path of the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired
+     * will be used.
      *
      * @return the cookie path set via {@link #setPath}, or <tt>null</tt> if {@link #setPath} was never called
      *
@@ -117,7 +117,7 @@ public interface SessionCookieConfig {
      * @param comment the cookie comment to use
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setComment(String)
      * @see jakarta.servlet.http.Cookie#getVersion
@@ -139,16 +139,16 @@ public interface SessionCookieConfig {
      * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired as <i>HttpOnly</i>.
      *
      * <p>
-     * A cookie is marked as <tt>HttpOnly</tt> by adding the <tt>HttpOnly</tt> attribute to it. <i>HttpOnly</i> cookies
-     * are not supposed to be exposed to client-side scripting code, and may therefore help mitigate certain kinds of
-     * cross-site scripting attacks.
+     * A cookie is marked as <tt>HttpOnly</tt> by adding the <tt>HttpOnly</tt> attribute to it. <i>HttpOnly</i> cookies are
+     * not supposed to be exposed to client-side scripting code, and may therefore help mitigate certain kinds of cross-site
+     * scripting attacks.
      *
      * @param httpOnly true if the session tracking cookies created on behalf of the application represented by the
-     *                 <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired shall be marked
-     *                 as <i>HttpOnly</i>, false otherwise
+     * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired shall be marked as <i>HttpOnly</i>,
+     * false otherwise
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setHttpOnly(boolean)
      */
@@ -156,12 +156,11 @@ public interface SessionCookieConfig {
 
     /**
      * Checks if the session tracking cookies created on behalf of the application represented by the
-     * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired will be marked as
-     * <i>HttpOnly</i>.
+     * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired will be marked as <i>HttpOnly</i>.
      *
      * @return true if the session tracking cookies created on behalf of the application represented by the
-     *         <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired will be marked as
-     *         <i>HttpOnly</i>, false otherwise
+     * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired will be marked as <i>HttpOnly</i>,
+     * false otherwise
      *
      * @see jakarta.servlet.http.Cookie#isHttpOnly()
      */
@@ -174,17 +173,16 @@ public interface SessionCookieConfig {
      * <p>
      * One use case for marking a session tracking cookie as <tt>secure</tt>, even though the request that initiated the
      * session came over HTTP, is to support a topology where the web container is front-ended by an SSL offloading load
-     * balancer. In this case, the traffic between the client and the load balancer will be over HTTPS, whereas the
-     * traffic between the load balancer and the web container will be over HTTP.
+     * balancer. In this case, the traffic between the client and the load balancer will be over HTTPS, whereas the traffic
+     * between the load balancer and the web container will be over HTTP.
      *
      * @param secure true if the session tracking cookies created on behalf of the application represented by the
-     *               <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired shall be marked
-     *               as <i>secure</i> even if the request that initiated the corresponding session is using plain HTTP
-     *               instead of HTTPS, and false if they shall be marked as <i>secure</i> only if the request that
-     *               initiated the corresponding session was also secure
+     * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired shall be marked as <i>secure</i>
+     * even if the request that initiated the corresponding session is using plain HTTP instead of HTTPS, and false if they
+     * shall be marked as <i>secure</i> only if the request that initiated the corresponding session was also secure
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setSecure(boolean)
      * @see ServletRequest#isSecure()
@@ -197,10 +195,9 @@ public interface SessionCookieConfig {
      * even if the request that initiated the corresponding session is using plain HTTP instead of HTTPS.
      *
      * @return true if the session tracking cookies created on behalf of the application represented by the
-     *         <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired will be marked as
-     *         <i>secure</i> even if the request that initiated the corresponding session is using plain HTTP instead of
-     *         HTTPS, and false if they will be marked as <i>secure</i> only if the request that initiated the
-     *         corresponding session was also secure
+     * <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired will be marked as <i>secure</i>
+     * even if the request that initiated the corresponding session is using plain HTTP instead of HTTPS, and false if they
+     * will be marked as <i>secure</i> only if the request that initiated the corresponding session was also secure
      *
      * @see jakarta.servlet.http.Cookie#getSecure()
      * @see ServletRequest#isSecure()
@@ -208,30 +205,28 @@ public interface SessionCookieConfig {
     public boolean isSecure();
 
     /**
-     * Sets the lifetime (in seconds) for the session tracking cookies created on behalf of the application represented
-     * by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * Sets the lifetime (in seconds) for the session tracking cookies created on behalf of the application represented by
+     * the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * @param maxAge the lifetime (in seconds) of the session tracking cookies created on behalf of the application
-     *               represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *               acquired.
+     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
-     *                               acquired has already been initialized
+     * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setMaxAge
      */
     public void setMaxAge(int maxAge);
 
     /**
-     * Gets the lifetime (in seconds) of the session tracking cookies created on behalf of the application represented
-     * by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * Gets the lifetime (in seconds) of the session tracking cookies created on behalf of the application represented by
+     * the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
      *
      * <p>
      * By default, <tt>-1</tt> is returned.
      *
-     * @return the lifetime (in seconds) of the session tracking cookies created on behalf of the application
-     *         represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired, or
-     *         <tt>-1</tt> (the default)
+     * @return the lifetime (in seconds) of the session tracking cookies created on behalf of the application represented by
+     * the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired, or <tt>-1</tt> (the default)
      *
      * @see jakarta.servlet.http.Cookie#getMaxAge
      */

--- a/api/src/main/java/jakarta/servlet/UnavailableException.java
+++ b/api/src/main/java/jakarta/servlet/UnavailableException.java
@@ -55,7 +55,7 @@ public class UnavailableException extends ServletException {
      *
      * @param servlet the <code>Servlet</code> instance that is unavailable
      *
-     * @param msg     a <code>String</code> specifying the descriptive message
+     * @param msg a <code>String</code> specifying the descriptive message
      *
      */
     @Deprecated
@@ -69,12 +69,12 @@ public class UnavailableException extends ServletException {
      * @deprecated As of Java Servlet API 2.2, use {@link #UnavailableException(String, int)} instead.
      *
      * @param seconds an integer specifying the number of seconds the servlet expects to be unavailable; if zero or
-     *                negative, indicates that the servlet can't make an estimate
+     * negative, indicates that the servlet can't make an estimate
      *
      * @param servlet the <code>Servlet</code> that is unavailable
      * 
-     * @param msg     a <code>String</code> specifying the descriptive message, which can be written to a log file or
-     *                displayed for the user.
+     * @param msg a <code>String</code> specifying the descriptive message, which can be written to a log file or displayed
+     * for the user.
      *
      */
     @Deprecated
@@ -106,15 +106,15 @@ public class UnavailableException extends ServletException {
      * giving an estimate of how long it will be unavailable.
      * 
      * <p>
-     * In some cases, the servlet cannot make an estimate. For example, the servlet might know that a server it needs is
-     * not running, but not be able to report how long it will take to be restored to functionality. This can be
-     * indicated with a negative or zero value for the <code>seconds</code> argument.
+     * In some cases, the servlet cannot make an estimate. For example, the servlet might know that a server it needs is not
+     * running, but not be able to report how long it will take to be restored to functionality. This can be indicated with
+     * a negative or zero value for the <code>seconds</code> argument.
      *
-     * @param msg     a <code>String</code> specifying the descriptive message, which can be written to a log file or
-     *                displayed for the user.
+     * @param msg a <code>String</code> specifying the descriptive message, which can be written to a log file or displayed
+     * for the user.
      *
      * @param seconds an integer specifying the number of seconds the servlet expects to be unavailable; if zero or
-     *                negative, indicates that the servlet can't make an estimate
+     * negative, indicates that the servlet can't make an estimate
      *
      */
     public UnavailableException(String msg, int seconds) {
@@ -130,11 +130,11 @@ public class UnavailableException extends ServletException {
 
     /**
      *
-     * Returns a <code>boolean</code> indicating whether the servlet is permanently unavailable. If so, something is
-     * wrong with the servlet, and the system administrator must take some corrective action.
+     * Returns a <code>boolean</code> indicating whether the servlet is permanently unavailable. If so, something is wrong
+     * with the servlet, and the system administrator must take some corrective action.
      *
-     * @return <code>true</code> if the servlet is permanently unavailable; <code>false</code> if the servlet is
-     *         available or temporarily unavailable
+     * @return <code>true</code> if the servlet is permanently unavailable; <code>false</code> if the servlet is available
+     * or temporarily unavailable
      *
      */
     public boolean isPermanent() {
@@ -144,7 +144,7 @@ public class UnavailableException extends ServletException {
     /**
      * @deprecated As of Java Servlet API 2.2, with no replacement.
      *
-     *             Returns the servlet that is reporting its unavailability.
+     * Returns the servlet that is reporting its unavailability.
      * 
      * @return the <code>Servlet</code> object that is throwing the <code>UnavailableException</code>
      *
@@ -158,12 +158,12 @@ public class UnavailableException extends ServletException {
      * Returns the number of seconds the servlet expects to be temporarily unavailable.
      *
      * <p>
-     * If this method returns a negative number, the servlet is permanently unavailable or cannot provide an estimate of
-     * how long it will be unavailable. No effort is made to correct for the time elapsed since the exception was first
+     * If this method returns a negative number, the servlet is permanently unavailable or cannot provide an estimate of how
+     * long it will be unavailable. No effort is made to correct for the time elapsed since the exception was first
      * reported.
      *
-     * @return an integer specifying the number of seconds the servlet will be temporarily unavailable, or a negative
-     *         number if the servlet is permanently unavailable or cannot make an estimate
+     * @return an integer specifying the number of seconds the servlet will be temporarily unavailable, or a negative number
+     * if the servlet is permanently unavailable or cannot make an estimate
      *
      */
     public int getUnavailableSeconds() {

--- a/api/src/main/java/jakarta/servlet/WriteListener.java
+++ b/api/src/main/java/jakarta/servlet/WriteListener.java
@@ -29,10 +29,10 @@ import java.util.EventListener;
 public interface WriteListener extends EventListener {
 
     /**
-     * When an instance of the WriteListener is registered with a {@link ServletOutputStream}, this method will be
-     * invoked by the container the first time when it is possible to write data. Subsequently the container will invoke
-     * this method if and only if the {@link jakarta.servlet.ServletOutputStream#isReady()} method has been called and has
-     * returned a value of <code>false</code> and a write operation has subsequently become possible.
+     * When an instance of the WriteListener is registered with a {@link ServletOutputStream}, this method will be invoked
+     * by the container the first time when it is possible to write data. Subsequently the container will invoke this method
+     * if and only if the {@link jakarta.servlet.ServletOutputStream#isReady()} method has been called and has returned a
+     * value of <code>false</code> and a write operation has subsequently become possible.
      *
      * @throws IOException if an I/O related error has occurred during processing
      */

--- a/api/src/main/java/jakarta/servlet/annotation/HandlesTypes.java
+++ b/api/src/main/java/jakarta/servlet/annotation/HandlesTypes.java
@@ -17,10 +17,10 @@
 
 package jakarta.servlet.annotation;
 
-import java.lang.annotation.Target;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * This annotation is used to declare the class types that a {@link jakarta.servlet.ServletContainerInitializer
@@ -35,17 +35,17 @@ import java.lang.annotation.RetentionPolicy;
 public @interface HandlesTypes {
 
     /**
-     * The classes in which a {@link jakarta.servlet.ServletContainerInitializer ServletContainerInitializer} has
-     * expressed interest.
+     * The classes in which a {@link jakarta.servlet.ServletContainerInitializer ServletContainerInitializer} has expressed
+     * interest.
      *
      * <p>
-     * If an implementation of <tt>ServletContainerInitializer</tt> specifies this annotation, the Servlet container
-     * must pass the <tt>Set</tt> of application classes that extend, implement, or have been annotated with the class
-     * types listed by this annotation to the {@link jakarta.servlet.ServletContainerInitializer#onStartup} method of the
+     * If an implementation of <tt>ServletContainerInitializer</tt> specifies this annotation, the Servlet container must
+     * pass the <tt>Set</tt> of application classes that extend, implement, or have been annotated with the class types
+     * listed by this annotation to the {@link jakarta.servlet.ServletContainerInitializer#onStartup} method of the
      * ServletContainerInitializer (if no matching classes are found, <tt>null</tt> must be passed instead)
      * 
      * @return the classes in which {@link jakarta.servlet.ServletContainerInitializer ServletContainerInitializer} has
-     *         expressed interest
+     * expressed interest
      */
     Class<?>[] value();
 }

--- a/api/src/main/java/jakarta/servlet/annotation/HttpConstraint.java
+++ b/api/src/main/java/jakarta/servlet/annotation/HttpConstraint.java
@@ -17,11 +17,11 @@
 
 package jakarta.servlet.annotation;
 
+import jakarta.servlet.annotation.ServletSecurity.EmptyRoleSemantic;
+import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import jakarta.servlet.annotation.ServletSecurity.EmptyRoleSemantic;
-import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 
 /**
  * This annotation is used within the {@link ServletSecurity} annotation to represent the security constraints to be
@@ -43,17 +43,17 @@ import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 public @interface HttpConstraint {
 
     /**
-     * The default authorization semantic. This value is insignificant when <code>rolesAllowed</code> returns a
-     * non-empty array, and should not be specified when a non-empty array is specified for <tt>rolesAllowed</tt>.
+     * The default authorization semantic. This value is insignificant when <code>rolesAllowed</code> returns a non-empty
+     * array, and should not be specified when a non-empty array is specified for <tt>rolesAllowed</tt>.
      *
      * @return the {@link EmptyRoleSemantic} to be applied when <code>rolesAllowed</code> returns an empty (that is,
-     *         zero-length) array.
+     * zero-length) array.
      */
     EmptyRoleSemantic value() default EmptyRoleSemantic.PERMIT;
 
     /**
-     * The data protection requirements (i.e., whether or not SSL/TLS is required) that must be satisfied by the
-     * connections on which requests arrive.
+     * The data protection requirements (i.e., whether or not SSL/TLS is required) that must be satisfied by the connections
+     * on which requests arrive.
      * 
      * @return the {@link TransportGuarantee} indicating the data protection that must be provided by the connection.
      */
@@ -62,18 +62,16 @@ public @interface HttpConstraint {
     /**
      * The names of the authorized roles.
      *
-     * Duplicate role names appearing in rolesAllowed are insignificant and may be discarded during runtime processing
-     * of the annotation. The String <tt>"*"</tt> has no special meaning as a role name (should it occur in
-     * rolesAllowed).
+     * Duplicate role names appearing in rolesAllowed are insignificant and may be discarded during runtime processing of
+     * the annotation. The String <tt>"*"</tt> has no special meaning as a role name (should it occur in rolesAllowed).
      *
      * @return an array of zero or more role names. When the array contains zero elements, its meaning depends on the
-     *         <code>EmptyRoleSemantic</code> returned by the <code>value</code> method. If <code>value</code> returns
-     *         <tt>DENY</tt>, and <code>rolesAllowed</code> returns a zero length array, access is to be denied
-     *         independent of authentication state and identity. Conversely, if <code>value</code> returns
-     *         <code>PERMIT</code>, it indicates that access is to be allowed independent of authentication state and
-     *         identity. When the array contains the names of one or more roles, it indicates that access is contingent
-     *         on membership in at least one of the named roles (independent of the <code>EmptyRoleSemantic</code>
-     *         returned by the <code>value</code> method).
+     * <code>EmptyRoleSemantic</code> returned by the <code>value</code> method. If <code>value</code> returns
+     * <tt>DENY</tt>, and <code>rolesAllowed</code> returns a zero length array, access is to be denied independent of
+     * authentication state and identity. Conversely, if <code>value</code> returns <code>PERMIT</code>, it indicates that
+     * access is to be allowed independent of authentication state and identity. When the array contains the names of one or
+     * more roles, it indicates that access is contingent on membership in at least one of the named roles (independent of
+     * the <code>EmptyRoleSemantic</code> returned by the <code>value</code> method).
      */
     String[] rolesAllowed() default {};
 }

--- a/api/src/main/java/jakarta/servlet/annotation/HttpMethodConstraint.java
+++ b/api/src/main/java/jakarta/servlet/annotation/HttpMethodConstraint.java
@@ -17,11 +17,11 @@
 
 package jakarta.servlet.annotation;
 
+import jakarta.servlet.annotation.ServletSecurity.EmptyRoleSemantic;
+import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import jakarta.servlet.annotation.ServletSecurity.EmptyRoleSemantic;
-import jakarta.servlet.annotation.ServletSecurity.TransportGuarantee;
 
 /**
  * This annotation is used within the {@link ServletSecurity} annotation to represent security constraints on specific
@@ -36,23 +36,23 @@ public @interface HttpMethodConstraint {
     /**
      * Http protocol method name
      *
-     * @return the name of an HTTP protocol method. <code>value</code> may not be null, or the empty string, and must be
-     *         a legitimate HTTP Method name as defined by RFC 2616.
+     * @return the name of an HTTP protocol method. <code>value</code> may not be null, or the empty string, and must be a
+     * legitimate HTTP Method name as defined by RFC 2616.
      */
     String value();
 
     /**
-     * The default authorization semantic. This value is insignificant when <code>rolesAllowed</code> returns a
-     * non-empty array, and should not be specified when a non-empty array is specified for <tt>rolesAllowed</tt>.
+     * The default authorization semantic. This value is insignificant when <code>rolesAllowed</code> returns a non-empty
+     * array, and should not be specified when a non-empty array is specified for <tt>rolesAllowed</tt>.
      *
      * @return the {@link EmptyRoleSemantic} to be applied when <code>rolesAllowed</code> returns an empty (that is,
-     *         zero-length) array.
+     * zero-length) array.
      */
     EmptyRoleSemantic emptyRoleSemantic() default EmptyRoleSemantic.PERMIT;
 
     /**
-     * The data protection requirements (i.e., whether or not SSL/TLS is required) that must be satisfied by the
-     * connections on which requests arrive.
+     * The data protection requirements (i.e., whether or not SSL/TLS is required) that must be satisfied by the connections
+     * on which requests arrive.
      *
      * @return the {@link TransportGuarantee} indicating the data protection that must be provided by the connection.
      */
@@ -61,18 +61,16 @@ public @interface HttpMethodConstraint {
     /**
      * The names of the authorized roles.
      *
-     * Duplicate role names appearing in rolesAllowed are insignificant and may be discarded during runtime processing
-     * of the annotation. The String <tt>"*"</tt> has no special meaning as a role name (should it occur in
-     * rolesAllowed).
+     * Duplicate role names appearing in rolesAllowed are insignificant and may be discarded during runtime processing of
+     * the annotation. The String <tt>"*"</tt> has no special meaning as a role name (should it occur in rolesAllowed).
      *
-     * @return an array of zero or more role names. When the array contains zero elements, its meaning depends on the
-     *         value returned by <code>emptyRoleSemantic</code>. If <code>emptyRoleSemantic</code> returns
-     *         <tt>DENY</tt>, and <code>rolesAllowed</code> returns a zero length array, access is to be denied
-     *         independent of authentication state and identity. Conversely, if <code>emptyRoleSemantic</code> returns
-     *         <code>PERMIT</code>, it indicates that access is to be allowed independent of authentication state and
-     *         identity. When the array contains the names of one or more roles, it indicates that access is contingent
-     *         on membership in at least one of the named roles (independent of the value returned by
-     *         <code>emptyRoleSemantic</code>).
+     * @return an array of zero or more role names. When the array contains zero elements, its meaning depends on the value
+     * returned by <code>emptyRoleSemantic</code>. If <code>emptyRoleSemantic</code> returns <tt>DENY</tt>, and
+     * <code>rolesAllowed</code> returns a zero length array, access is to be denied independent of authentication state and
+     * identity. Conversely, if <code>emptyRoleSemantic</code> returns <code>PERMIT</code>, it indicates that access is to
+     * be allowed independent of authentication state and identity. When the array contains the names of one or more roles,
+     * it indicates that access is contingent on membership in at least one of the named roles (independent of the value
+     * returned by <code>emptyRoleSemantic</code>).
      */
     String[] rolesAllowed() default {};
 }

--- a/api/src/main/java/jakarta/servlet/annotation/MultipartConfig.java
+++ b/api/src/main/java/jakarta/servlet/annotation/MultipartConfig.java
@@ -17,10 +17,10 @@
 
 package jakarta.servlet.annotation;
 
-import java.lang.annotation.Target;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotation that may be specified on a {@link jakarta.servlet.Servlet} class, indicating that instances of the

--- a/api/src/main/java/jakarta/servlet/annotation/ServletSecurity.java
+++ b/api/src/main/java/jakarta/servlet/annotation/ServletSecurity.java
@@ -20,9 +20,9 @@ package jakarta.servlet.annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
-import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * This annotation is used on a Servlet implementation class to specify security constraints to be enforced by a Servlet
@@ -41,14 +41,14 @@ public @interface ServletSecurity {
      * Defines the access semantic to be applied to an empty rolesAllowed array.
      */
     enum EmptyRoleSemantic {
-    /**
-     * access is to be permitted independent of authentication state and identity.
-     */
-    PERMIT,
-    /**
-     * access is to be denied independent of authentication state and identity.
-     */
-    DENY
+        /**
+         * access is to be permitted independent of authentication state and identity.
+         */
+        PERMIT,
+        /**
+         * access is to be denied independent of authentication state and identity.
+         */
+        DENY
     }
 
     /**
@@ -74,13 +74,12 @@ public @interface ServletSecurity {
     HttpConstraint value() default @HttpConstraint;
 
     /**
-     * Get the HTTP method specific constraints. Each {@link HttpMethodConstraint} names an HTTP protocol method and
-     * defines the protection to be applied to it.
+     * Get the HTTP method specific constraints. Each {@link HttpMethodConstraint} names an HTTP protocol method and defines
+     * the protection to be applied to it.
      *
      * @return an array of {@link HttpMethodConstraint} elements each defining the protection to be applied to one HTTP
-     *         protocol method. For any HTTP method name, there must be at most one corresponding element in the
-     *         returned array. If the returned array is of zero length, it indicates that no HTTP method specific
-     *         constraints are defined.
+     * protocol method. For any HTTP method name, there must be at most one corresponding element in the returned array. If
+     * the returned array is of zero length, it indicates that no HTTP method specific constraints are defined.
      */
     HttpMethodConstraint[] httpMethodConstraints() default {};
 }

--- a/api/src/main/java/jakarta/servlet/annotation/WebFilter.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebFilter.java
@@ -17,12 +17,12 @@
 
 package jakarta.servlet.annotation;
 
+import jakarta.servlet.DispatcherType;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import jakarta.servlet.DispatcherType;
 
 /**
  * Annotation used to declare a servlet filter.

--- a/api/src/main/java/jakarta/servlet/annotation/WebInitParam.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebInitParam.java
@@ -17,11 +17,11 @@
 
 package jakarta.servlet.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.lang.annotation.Documented;
 
 /**
  * This annotation is used on a Servlet or Filter implementation class to specify an initialization parameter.

--- a/api/src/main/java/jakarta/servlet/annotation/WebListener.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebListener.java
@@ -26,11 +26,11 @@ import java.lang.annotation.Target;
 /**
  * This annotation is used to declare a WebListener.
  *
- * Any class annotated with WebListener must implement one or more of the {@link jakarta.servlet.ServletContextListener},
- * {@link jakarta.servlet.ServletContextAttributeListener}, {@link jakarta.servlet.ServletRequestListener},
- * {@link jakarta.servlet.ServletRequestAttributeListener}, {@link jakarta.servlet.http.HttpSessionListener}, or
- * {@link jakarta.servlet.http.HttpSessionAttributeListener}, or {@link jakarta.servlet.http.HttpSessionIdListener}
- * interfaces.
+ * Any class annotated with WebListener must implement one or more of the
+ * {@link jakarta.servlet.ServletContextListener}, {@link jakarta.servlet.ServletContextAttributeListener},
+ * {@link jakarta.servlet.ServletRequestListener}, {@link jakarta.servlet.ServletRequestAttributeListener},
+ * {@link jakarta.servlet.http.HttpSessionListener}, or {@link jakarta.servlet.http.HttpSessionAttributeListener}, or
+ * {@link jakarta.servlet.http.HttpSessionIdListener} interfaces.
  * 
  * @since Servlet 3.0
  */

--- a/api/src/main/java/jakarta/servlet/annotation/WebServlet.java
+++ b/api/src/main/java/jakarta/servlet/annotation/WebServlet.java
@@ -17,11 +17,11 @@
 
 package jakarta.servlet.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Retention;
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotation used to declare a servlet.

--- a/api/src/main/java/jakarta/servlet/annotation/package.html
+++ b/api/src/main/java/jakarta/servlet/annotation/package.html
@@ -15,20 +15,11 @@
 
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
--->
-
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<HTML>
-<HEAD>
-
-
-</HEAD>
-<BODY BGCOLOR="white">
-
-The jakarta.servlet.annotation package contains a number of annotations 
-that allow users to use annotations to declare servlets, filters,
-listeners and specify the metadata for the declared component.
-
-@since Servlet 3.0
-</BODY>
-</HTML>
+--><!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+    <head> 
+    </head> 
+    <body bgcolor="white">
+         The jakarta.servlet.annotation package contains a number of annotations that allow users to use annotations to declare servlets, filters, listeners and specify the metadata for the declared component. @since Servlet 3.0  
+    </body>
+</html>

--- a/api/src/main/java/jakarta/servlet/descriptor/JspConfigDescriptor.java
+++ b/api/src/main/java/jakarta/servlet/descriptor/JspConfigDescriptor.java
@@ -38,7 +38,7 @@ public interface JspConfigDescriptor {
      * Any changes to the returned <code>Collection</code> must not affect this <code>JspConfigDescriptor</code>.
      *
      * @return a (possibly empty) <code>Collection</code> of the <code>&lt;taglib&gt;</code> child elements of the
-     *         <code>&lt;jsp-config&gt;</code> element represented by this <code>JspConfigDescriptor</code>
+     * <code>&lt;jsp-config&gt;</code> element represented by this <code>JspConfigDescriptor</code>
      */
     public Collection<TaglibDescriptor> getTaglibs();
 
@@ -49,8 +49,8 @@ public interface JspConfigDescriptor {
      * <p>
      * Any changes to the returned <code>Collection</code> must not affect this <code>JspConfigDescriptor</code>.
      *
-     * @return a (possibly empty) <code>Collection</code> of the <code>&lt;jsp-property-group&gt;</code> child elements
-     *         of the <code>&lt;jsp-config&gt;</code> element represented by this <code>JspConfigDescriptor</code>
+     * @return a (possibly empty) <code>Collection</code> of the <code>&lt;jsp-property-group&gt;</code> child elements of
+     * the <code>&lt;jsp-config&gt;</code> element represented by this <code>JspConfigDescriptor</code>
      */
     public Collection<JspPropertyGroupDescriptor> getJspPropertyGroups();
 }

--- a/api/src/main/java/jakarta/servlet/descriptor/JspPropertyGroupDescriptor.java
+++ b/api/src/main/java/jakarta/servlet/descriptor/JspPropertyGroupDescriptor.java
@@ -37,8 +37,8 @@ public interface JspPropertyGroupDescriptor {
      * <p>
      * Any changes to the returned <code>Collection</code> must not affect this <code>JspPropertyGroupDescriptor</code>.
      *
-     * @return a (possibly empty) <code>Collection</code> of the URL patterns of the JSP property group represented by
-     *         this <code>JspPropertyGroupDescriptor</code>
+     * @return a (possibly empty) <code>Collection</code> of the URL patterns of the JSP property group represented by this
+     * <code>JspPropertyGroupDescriptor</code>
      */
     public Collection<String> getUrlPatterns();
 
@@ -52,16 +52,16 @@ public interface JspPropertyGroupDescriptor {
     public String getElIgnored();
 
     /**
-     * Gets the value of the <code>page-encoding</code> configuration, which specifies the default page encoding for any
-     * JSP pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
+     * Gets the value of the <code>page-encoding</code> configuration, which specifies the default page encoding for any JSP
+     * pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>page-encoding</code> configuration, or null if unspecified
      */
     public String getPageEncoding();
 
     /**
-     * Gets the value of the <code>scripting-invalid</code> configuration, which specifies whether scripting is enabled
-     * for any JSP pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
+     * Gets the value of the <code>scripting-invalid</code> configuration, which specifies whether scripting is enabled for
+     * any JSP pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>scripting-invalid</code> configuration, or null if unspecified
      */
@@ -84,7 +84,7 @@ public interface JspPropertyGroupDescriptor {
      * Any changes to the returned <code>Collection</code> must not affect this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return a (possibly empty) <code>Collection</code> of the <code>include-prelude</code> configuration of the JSP
-     *         property group represented by this <code>JspPropertyGroupDescriptor</code>
+     * property group represented by this <code>JspPropertyGroupDescriptor</code>
      */
     public Collection<String> getIncludePreludes();
 
@@ -95,51 +95,50 @@ public interface JspPropertyGroupDescriptor {
      * <p>
      * Any changes to the returned <code>Collection</code> must not affect this <code>JspPropertyGroupDescriptor</code>.
      *
-     * @return a (possibly empty) <code>Collection</code> of the <code>include-coda</code> configuration of the JSP
-     *         property group represented by this <code>JspPropertyGroupDescriptor</code>
+     * @return a (possibly empty) <code>Collection</code> of the <code>include-coda</code> configuration of the JSP property
+     * group represented by this <code>JspPropertyGroupDescriptor</code>
      */
     public Collection<String> getIncludeCodas();
 
     /**
      * Gets the value of the <code>deferred-syntax-allowed-as-literal</code> configuration, which specifies whether the
-     * character sequence <code>&quot;#{&quot;</code>, which is normally reserved for Expression Language (EL)
-     * expressions, will cause a translation error if it appears as a String literal in any JSP pages mapped to the JSP
-     * property group represented by this <code>JspPropertyGroupDescriptor</code>.
+     * character sequence <code>&quot;#{&quot;</code>, which is normally reserved for Expression Language (EL) expressions,
+     * will cause a translation error if it appears as a String literal in any JSP pages mapped to the JSP property group
+     * represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>deferred-syntax-allowed-as-literal</code> configuration, or null if unspecified
      */
     public String getDeferredSyntaxAllowedAsLiteral();
 
     /**
-     * Gets the value of the <code>trim-directive-whitespaces</code> configuration, which specifies whether template
-     * text containing only whitespaces must be removed from the response output of any JSP pages mapped to the JSP
-     * property group represented by this <code>JspPropertyGroupDescriptor</code>.
+     * Gets the value of the <code>trim-directive-whitespaces</code> configuration, which specifies whether template text
+     * containing only whitespaces must be removed from the response output of any JSP pages mapped to the JSP property
+     * group represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>trim-directive-whitespaces</code> configuration, or null if unspecified
      */
     public String getTrimDirectiveWhitespaces();
 
     /**
-     * Gets the value of the <code>default-content-type</code> configuration, which specifies the default response
-     * content type for any JSP pages mapped to the JSP property group represented by this
-     * <code>JspPropertyGroupDescriptor</code>.
+     * Gets the value of the <code>default-content-type</code> configuration, which specifies the default response content
+     * type for any JSP pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>default-content-type</code> configuration, or null if unspecified
      */
     public String getDefaultContentType();
 
     /**
-     * Gets the value of the <code>buffer</code> configuration, which specifies the default size of the response buffer
-     * for any JSP pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
+     * Gets the value of the <code>buffer</code> configuration, which specifies the default size of the response buffer for
+     * any JSP pages mapped to the JSP property group represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>buffer</code> configuration, or null if unspecified
      */
     public String getBuffer();
 
     /**
-     * Gets the value of the <code>error-on-undeclared-namespace</code> configuration, which specifies whether an error
-     * will be raised at translation time if tag with an undeclared namespace is used in any JSP pages mapped to the JSP
-     * property group represented by this <code>JspPropertyGroupDescriptor</code>.
+     * Gets the value of the <code>error-on-undeclared-namespace</code> configuration, which specifies whether an error will
+     * be raised at translation time if tag with an undeclared namespace is used in any JSP pages mapped to the JSP property
+     * group represented by this <code>JspPropertyGroupDescriptor</code>.
      *
      * @return the value of the <code>error-on-undeclared-namespace</code> configuration, or null if unspecified
      */

--- a/api/src/main/java/jakarta/servlet/descriptor/package.html
+++ b/api/src/main/java/jakarta/servlet/descriptor/package.html
@@ -1,7 +1,7 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <html>
-<head>
-<!--
+    <head> 
+        <!--
 
     Copyright (c) 2009, 2020 Oracle and/or its affiliates and others.
     All rights reserved.
@@ -18,13 +18,13 @@
 
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
--->
-
-</head>
-<body bgcolor="white">
-
-Provides programmatic access to a web application's configuration information that was aggregated from the <code>web.xml</code> and <code>web-fragment.xml</code> descriptors.
-
-@since Servlet 3.0
-</body>
+--> 
+    </head> 
+    <body bgcolor="white">
+         Provides programmatic access to a web application's configuration information that was aggregated from the 
+        <code>web.xml</code>
+         and 
+        <code>web-fragment.xml</code>
+         descriptors. @since Servlet 3.0  
+    </body>
 </html>

--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -108,16 +108,15 @@ public class Cookie implements Cloneable, Serializable {
      * cookie's value can be changed after creation with the <code>setValue</code> method.
      *
      * <p>
-     * By default, cookies are created according to the Netscape cookie specification. The version can be changed with
-     * the <code>setVersion</code> method.
+     * By default, cookies are created according to the Netscape cookie specification. The version can be changed with the
+     * <code>setVersion</code> method.
      *
-     * @param name  the name of the cookie
+     * @param name the name of the cookie
      *
      * @param value the value of the cookie
      *
-     * @throws IllegalArgumentException if the cookie name is null or empty or contains any illegal characters (for
-     *                                  example, a comma, space, or semicolon) or matches a token reserved for use by
-     *                                  the cookie protocol
+     * @throws IllegalArgumentException if the cookie name is null or empty or contains any illegal characters (for example,
+     * a comma, space, or semicolon) or matches a token reserved for use by the cookie protocol
      *
      * @see #setValue
      * @see #setVersion
@@ -144,8 +143,8 @@ public class Cookie implements Cloneable, Serializable {
     }
 
     /**
-     * Specifies a comment that describes a cookie's purpose. The comment is useful if the browser presents the cookie
-     * to the user. Comments are not supported by Netscape Version 0 cookies.
+     * Specifies a comment that describes a cookie's purpose. The comment is useful if the browser presents the cookie to
+     * the user. Comments are not supported by Netscape Version 0 cookies.
      *
      * @param purpose a <code>String</code> specifying the comment to display to the user
      *
@@ -173,8 +172,8 @@ public class Cookie implements Cloneable, Serializable {
      * <p>
      * The form of the domain name is specified by RFC 2109. A domain name begins with a dot (<code>.foo.com</code>) and
      * means that the cookie is visible to servers in a specified Domain Name System (DNS) zone (for example,
-     * <code>www.foo.com</code>, but not <code>a.b.foo.com</code>). By default, cookies are only returned to the server
-     * that sent them.
+     * <code>www.foo.com</code>, but not <code>a.b.foo.com</code>). By default, cookies are only returned to the server that
+     * sent them.
      *
      * @param domain the domain name within which this cookie is visible; form is according to RFC 2109
      *
@@ -202,15 +201,15 @@ public class Cookie implements Cloneable, Serializable {
      * Sets the maximum age in seconds for this Cookie.
      *
      * <p>
-     * A positive value indicates that the cookie will expire after that many seconds have passed. Note that the value
-     * is the <i>maximum</i> age when the cookie will expire, not the cookie's current age.
+     * A positive value indicates that the cookie will expire after that many seconds have passed. Note that the value is
+     * the <i>maximum</i> age when the cookie will expire, not the cookie's current age.
      *
      * <p>
-     * A negative value means that the cookie is not stored persistently and will be deleted when the Web browser exits.
-     * A zero value causes the cookie to be deleted.
+     * A negative value means that the cookie is not stored persistently and will be deleted when the Web browser exits. A
+     * zero value causes the cookie to be deleted.
      *
-     * @param expiry an integer specifying the maximum age of the cookie in seconds; if negative, means the cookie is
-     *               not stored; if zero, deletes the cookie
+     * @param expiry an integer specifying the maximum age of the cookie in seconds; if negative, means the cookie is not
+     * stored; if zero, deletes the cookie
      *
      * @see #getMaxAge
      */
@@ -224,8 +223,8 @@ public class Cookie implements Cloneable, Serializable {
      * <p>
      * By default, <code>-1</code> is returned, which indicates that the cookie will persist until browser shutdown.
      *
-     * @return an integer specifying the maximum age of the cookie in seconds; if negative, means the cookie persists
-     *         until browser shutdown
+     * @return an integer specifying the maximum age of the cookie in seconds; if negative, means the cookie persists until
+     * browser shutdown
      *
      * @see #setMaxAge
      */
@@ -254,8 +253,8 @@ public class Cookie implements Cloneable, Serializable {
     }
 
     /**
-     * Returns the path on the server to which the browser returns this cookie. The cookie is visible to all subpaths on
-     * the server.
+     * Returns the path on the server to which the browser returns this cookie. The cookie is visible to all subpaths on the
+     * server.
      *
      * @return a <code>String</code> specifying a path that contains a servlet name, for example, <i>/catalog</i>
      *
@@ -271,8 +270,8 @@ public class Cookie implements Cloneable, Serializable {
      * <p>
      * The default value is <code>false</code>.
      *
-     * @param flag if <code>true</code>, sends the cookie from the browser to the server only when using a secure
-     *             protocol; if <code>false</code>, sent on any protocol
+     * @param flag if <code>true</code>, sends the cookie from the browser to the server only when using a secure protocol;
+     * if <code>false</code>, sent on any protocol
      *
      * @see #getSecure
      */
@@ -281,8 +280,8 @@ public class Cookie implements Cloneable, Serializable {
     }
 
     /**
-     * Returns <code>true</code> if the browser is sending cookies only over a secure protocol, or <code>false</code> if
-     * the browser can send cookies using any protocol.
+     * Returns <code>true</code> if the browser is sending cookies only over a secure protocol, or <code>false</code> if the
+     * browser can send cookies using any protocol.
      *
      * @return <code>true</code> if the browser uses a secure protocol, <code>false</code> otherwise
      *
@@ -308,9 +307,9 @@ public class Cookie implements Cloneable, Serializable {
      * If you use a binary value, you may want to use BASE64 encoding.
      *
      * <p>
-     * With Version 0 cookies, values should not contain white space, brackets, parentheses, equals signs, commas,
-     * double quotes, slashes, question marks, at signs, colons, and semicolons. Empty values may not behave the same
-     * way on all browsers.
+     * With Version 0 cookies, values should not contain white space, brackets, parentheses, equals signs, commas, double
+     * quotes, slashes, question marks, at signs, colons, and semicolons. Empty values may not behave the same way on all
+     * browsers.
      *
      * @param newValue the new value of the cookie
      *
@@ -333,8 +332,8 @@ public class Cookie implements Cloneable, Serializable {
 
     /**
      * Returns the version of the protocol this cookie complies with. Version 1 complies with RFC 2109, and version 0
-     * complies with the original cookie specification drafted by Netscape. Cookies provided by a browser use and
-     * identify the browser's cookie version.
+     * complies with the original cookie specification drafted by Netscape. Cookies provided by a browser use and identify
+     * the browser's cookie version.
      * 
      * @return 0 if the cookie complies with the original Netscape specification; 1 if the cookie complies with RFC 2109
      *
@@ -353,8 +352,8 @@ public class Cookie implements Cloneable, Serializable {
      * <p>
      * Since RFC 2109 is still somewhat new, consider version 1 as experimental; do not use it yet on production sites.
      *
-     * @param v 0 if the cookie should comply with the original Netscape specification; 1 if the cookie should comply
-     *          with RFC 2109
+     * @param v 0 if the cookie should comply with the original Netscape specification; 1 if the cookie should comply with
+     * RFC 2109
      *
      * @see #getVersion
      */
@@ -401,8 +400,8 @@ public class Cookie implements Cloneable, Serializable {
      * <tt>HttpOnly</tt> attribute to it.
      *
      * <p>
-     * <i>HttpOnly</i> cookies are not supposed to be exposed to client-side scripting code, and may therefore help
-     * mitigate certain kinds of cross-site scripting attacks.
+     * <i>HttpOnly</i> cookies are not supposed to be exposed to client-side scripting code, and may therefore help mitigate
+     * certain kinds of cross-site scripting attacks.
      *
      * @param isHttpOnly true if this cookie is to be marked as <i>HttpOnly</i>, false otherwise
      *

--- a/api/src/main/java/jakarta/servlet/http/HttpFilter.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpFilter.java
@@ -17,12 +17,12 @@
 
 package jakarta.servlet.http;
 
-import java.io.IOException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.GenericFilter;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
+import java.io.IOException;
 
 /**
  *
@@ -60,10 +60,10 @@ public abstract class HttpFilter extends GenericFilter {
     /**
      *
      * <p>
-     * The <code>doFilter</code> method of the Filter is called by the container each time a request/response pair is
-     * passed through the chain due to a client request for a resource at the end of the chain. The FilterChain passed
-     * in to this method allows the Filter to pass on the request and response to the next entity in the chain. There's
-     * no need to override this method.
+     * The <code>doFilter</code> method of the Filter is called by the container each time a request/response pair is passed
+     * through the chain due to a client request for a resource at the end of the chain. The FilterChain passed in to this
+     * method allows the Filter to pass on the request and response to the next entity in the chain. There's no need to
+     * override this method.
      * </p>
      * 
      * <p>
@@ -74,16 +74,16 @@ public abstract class HttpFilter extends GenericFilter {
      * method is called.
      * </p>
      *
-     * @param req   a {@link ServletRequest} object that contains the request the client has made of the filter
+     * @param req a {@link ServletRequest} object that contains the request the client has made of the filter
      *
-     * @param res   a {@link ServletResponse} object that contains the response the filter sends to the client
+     * @param res a {@link ServletResponse} object that contains the response the filter sends to the client
      * 
      * @param chain the <code>FilterChain</code> for invoking the next filter or the resource
      * 
-     * @throws IOException      if an input or output error is detected when the filter handles the request
+     * @throws IOException if an input or output error is detected when the filter handles the request
      *
-     * @throws ServletException if the request for the could not be handled or either parameter is not an instance of
-     *                          the respective {@link HttpServletRequest} or {@link HttpServletResponse}.
+     * @throws ServletException if the request for the could not be handled or either parameter is not an instance of the
+     * respective {@link HttpServletRequest} or {@link HttpServletResponse}.
      *
      * @since Servlet 4.0
      */
@@ -100,22 +100,22 @@ public abstract class HttpFilter extends GenericFilter {
     /**
      *
      * <p>
-     * The <code>doFilter</code> method of the Filter is called by the container each time a request/response pair is
-     * passed through the chain due to a client request for a resource at the end of the chain. The FilterChain passed
-     * in to this method allows the Filter to pass on the request and response to the next entity in the chain.
+     * The <code>doFilter</code> method of the Filter is called by the container each time a request/response pair is passed
+     * through the chain due to a client request for a resource at the end of the chain. The FilterChain passed in to this
+     * method allows the Filter to pass on the request and response to the next entity in the chain.
      * </p>
      * 
      * <p>
      * The default implementation simply calls {@link FilterChain#doFilter}
      * </p>
      *
-     * @param req   a {@link HttpServletRequest} object that contains the request the client has made of the filter
+     * @param req a {@link HttpServletRequest} object that contains the request the client has made of the filter
      *
-     * @param res   a {@link HttpServletResponse} object that contains the response the filter sends to the client
+     * @param res a {@link HttpServletResponse} object that contains the response the filter sends to the client
      * 
      * @param chain the <code>FilterChain</code> for invoking the next filter or the resource
      * 
-     * @throws IOException      if an input or output error is detected when the filter handles the request
+     * @throws IOException if an input or output error is detected when the filter handles the request
      *
      * @throws ServletException if the request for the could not be handled
      *

--- a/api/src/main/java/jakarta/servlet/http/HttpServlet.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServlet.java
@@ -18,22 +18,20 @@
 
 package jakarta.servlet.http;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Method;
-import java.text.MessageFormat;
-import java.util.Enumeration;
-import java.util.ResourceBundle;
-
 import jakarta.servlet.GenericServlet;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.WriteListener;
-
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+import java.util.Enumeration;
+import java.util.ResourceBundle;
 
 /**
  *
@@ -96,18 +94,18 @@ public abstract class HttpServlet extends GenericServlet {
      * Called by the server (via the <code>service</code> method) to allow a servlet to handle a GET request.
      *
      * <p>
-     * Overriding this method to support a GET request also automatically supports an HTTP HEAD request. A HEAD request
-     * is a GET request that returns no body in the response, only the request header fields.
+     * Overriding this method to support a GET request also automatically supports an HTTP HEAD request. A HEAD request is a
+     * GET request that returns no body in the response, only the request header fields.
      *
      * <p>
-     * When overriding this method, read the request data, write the response headers, get the response's writer or
-     * output stream object, and finally, write the response data. It's best to include content type and encoding. When
-     * using a <code>PrintWriter</code> object to return the response, set the content type before accessing the
+     * When overriding this method, read the request data, write the response headers, get the response's writer or output
+     * stream object, and finally, write the response data. It's best to include content type and encoding. When using a
+     * <code>PrintWriter</code> object to return the response, set the content type before accessing the
      * <code>PrintWriter</code> object.
      *
      * <p>
-     * The servlet container must write the headers before committing the response, because in HTTP the headers must be
-     * sent before the response body.
+     * The servlet container must write the headers before committing the response, because in HTTP the headers must be sent
+     * before the response body.
      *
      * <p>
      * Where possible, set the Content-Length header (with the {@link jakarta.servlet.ServletResponse#setContentLength}
@@ -116,27 +114,27 @@ public abstract class HttpServlet extends GenericServlet {
      * buffer.
      *
      * <p>
-     * When using HTTP 1.1 chunked encoding (which means that the response has a Transfer-Encoding header), do not set
-     * the Content-Length header.
+     * When using HTTP 1.1 chunked encoding (which means that the response has a Transfer-Encoding header), do not set the
+     * Content-Length header.
      *
      * <p>
-     * The GET method should be safe, that is, without any side effects for which users are held responsible. For
-     * example, most form queries have no side effects. If a client request is intended to change stored data, the
-     * request should use some other HTTP method.
+     * The GET method should be safe, that is, without any side effects for which users are held responsible. For example,
+     * most form queries have no side effects. If a client request is intended to change stored data, the request should use
+     * some other HTTP method.
      *
      * <p>
-     * The GET method should also be idempotent, meaning that it can be safely repeated. Sometimes making a method safe
-     * also makes it idempotent. For example, repeating queries is both safe and idempotent, but buying a product online
-     * or modifying data is neither safe nor idempotent.
+     * The GET method should also be idempotent, meaning that it can be safely repeated. Sometimes making a method safe also
+     * makes it idempotent. For example, repeating queries is both safe and idempotent, but buying a product online or
+     * modifying data is neither safe nor idempotent.
      *
      * <p>
      * If the request is incorrectly formatted, <code>doGet</code> returns an HTTP "Bad Request" message.
      * 
-     * @param req  an {@link HttpServletRequest} object that contains the request the client has made of the servlet
+     * @param req an {@link HttpServletRequest} object that contains the request the client has made of the servlet
      *
      * @param resp an {@link HttpServletResponse} object that contains the response the servlet sends to the client
      * 
-     * @throws IOException      if an input or output error is detected when the servlet handles the GET request
+     * @throws IOException if an input or output error is detected when the servlet handles the GET request
      *
      * @throws ServletException if the request for the GET could not be handled
      *
@@ -154,18 +152,17 @@ public abstract class HttpServlet extends GenericServlet {
 
     /**
      *
-     * Returns the time the <code>HttpServletRequest</code> object was last modified, in milliseconds since midnight
-     * January 1, 1970 GMT. If the time is unknown, this method returns a negative number (the default).
+     * Returns the time the <code>HttpServletRequest</code> object was last modified, in milliseconds since midnight January
+     * 1, 1970 GMT. If the time is unknown, this method returns a negative number (the default).
      *
      * <p>
-     * Servlets that support HTTP GET requests and can quickly determine their last modification time should override
-     * this method. This makes browser and proxy caches work more effectively, reducing the load on server and network
-     * resources.
+     * Servlets that support HTTP GET requests and can quickly determine their last modification time should override this
+     * method. This makes browser and proxy caches work more effectively, reducing the load on server and network resources.
      *
      * @param req the <code>HttpServletRequest</code> object that is sent to the servlet
      *
-     * @return a <code>long</code> integer specifying the time the <code>HttpServletRequest</code> object was last
-     *         modified, in milliseconds since midnight, January 1, 1970 GMT, or -1 if the time is not known
+     * @return a <code>long</code> integer specifying the time the <code>HttpServletRequest</code> object was last modified,
+     * in milliseconds since midnight, January 1, 1970 GMT, or -1 if the time is not known
      */
     protected long getLastModified(HttpServletRequest req) {
         return -1;
@@ -176,22 +173,22 @@ public abstract class HttpServlet extends GenericServlet {
      *
      * <p>
      * Receives an HTTP HEAD request from the protected <code>service</code> method and handles the request. The client
-     * sends a HEAD request when it wants to see only the headers of a response, such as Content-Type or Content-Length.
-     * The HTTP HEAD method counts the output bytes in the response to set the Content-Length header accurately.
+     * sends a HEAD request when it wants to see only the headers of a response, such as Content-Type or Content-Length. The
+     * HTTP HEAD method counts the output bytes in the response to set the Content-Length header accurately.
      *
      * <p>
-     * If you override this method, you can avoid computing the response body and just set the response headers directly
-     * to improve performance. Make sure that the <code>doHead</code> method you write is both safe and idempotent (that
-     * is, protects itself from being called multiple times for one HTTP HEAD request).
+     * If you override this method, you can avoid computing the response body and just set the response headers directly to
+     * improve performance. Make sure that the <code>doHead</code> method you write is both safe and idempotent (that is,
+     * protects itself from being called multiple times for one HTTP HEAD request).
      *
      * <p>
      * If the HTTP HEAD request is incorrectly formatted, <code>doHead</code> returns an HTTP "Bad Request" message.
      *
-     * @param req  the request object that is passed to the servlet
+     * @param req the request object that is passed to the servlet
      * 
      * @param resp the response object that the servlet uses to return the headers to the clien
      *
-     * @throws IOException      if an input or output error occurs
+     * @throws IOException if an input or output error occurs
      *
      * @throws ServletException if the request for the HEAD could not be handled
      */
@@ -206,18 +203,18 @@ public abstract class HttpServlet extends GenericServlet {
      *
      * Called by the server (via the <code>service</code> method) to allow a servlet to handle a POST request.
      *
-     * The HTTP POST method allows the client to send data of unlimited length to the Web server a single time and is
-     * useful when posting information such as credit card numbers.
+     * The HTTP POST method allows the client to send data of unlimited length to the Web server a single time and is useful
+     * when posting information such as credit card numbers.
      *
      * <p>
-     * When overriding this method, read the request data, write the response headers, get the response's writer or
-     * output stream object, and finally, write the response data. It's best to include content type and encoding. When
-     * using a <code>PrintWriter</code> object to return the response, set the content type before accessing the
+     * When overriding this method, read the request data, write the response headers, get the response's writer or output
+     * stream object, and finally, write the response data. It's best to include content type and encoding. When using a
+     * <code>PrintWriter</code> object to return the response, set the content type before accessing the
      * <code>PrintWriter</code> object.
      *
      * <p>
-     * The servlet container must write the headers before committing the response, because in HTTP the headers must be
-     * sent before the response body.
+     * The servlet container must write the headers before committing the response, because in HTTP the headers must be sent
+     * before the response body.
      *
      * <p>
      * Where possible, set the Content-Length header (with the {@link jakarta.servlet.ServletResponse#setContentLength}
@@ -226,22 +223,22 @@ public abstract class HttpServlet extends GenericServlet {
      * buffer.
      *
      * <p>
-     * When using HTTP 1.1 chunked encoding (which means that the response has a Transfer-Encoding header), do not set
-     * the Content-Length header.
+     * When using HTTP 1.1 chunked encoding (which means that the response has a Transfer-Encoding header), do not set the
+     * Content-Length header.
      *
      * <p>
-     * This method does not need to be either safe or idempotent. Operations requested through POST can have side
-     * effects for which the user can be held accountable, for example, updating stored data or buying items online.
+     * This method does not need to be either safe or idempotent. Operations requested through POST can have side effects
+     * for which the user can be held accountable, for example, updating stored data or buying items online.
      *
      * <p>
      * If the HTTP POST request is incorrectly formatted, <code>doPost</code> returns an HTTP "Bad Request" message.
      *
      *
-     * @param req  an {@link HttpServletRequest} object that contains the request the client has made of the servlet
+     * @param req an {@link HttpServletRequest} object that contains the request the client has made of the servlet
      *
      * @param resp an {@link HttpServletResponse} object that contains the response the servlet sends to the client
      * 
-     * @throws IOException      if an input or output error is detected when the servlet handles the request
+     * @throws IOException if an input or output error is detected when the servlet handles the request
      *
      * @throws ServletException if the request for the POST could not be handled
      *
@@ -266,23 +263,23 @@ public abstract class HttpServlet extends GenericServlet {
      * <p>
      * When overriding this method, leave intact any content headers sent with the request (including Content-Length,
      * Content-Type, Content-Transfer-Encoding, Content-Encoding, Content-Base, Content-Language, Content-Location,
-     * Content-MD5, and Content-Range). If your method cannot handle a content header, it must issue an error message
-     * (HTTP 501 - Not Implemented) and discard the request. For more information on HTTP 1.1, see RFC 2616
+     * Content-MD5, and Content-Range). If your method cannot handle a content header, it must issue an error message (HTTP
+     * 501 - Not Implemented) and discard the request. For more information on HTTP 1.1, see RFC 2616
      * <a href="http://www.ietf.org/rfc/rfc2616.txt"></a>.
      *
      * <p>
-     * This method does not need to be either safe or idempotent. Operations that <code>doPut</code> performs can have
-     * side effects for which the user can be held accountable. When using this method, it may be useful to save a copy
-     * of the affected URL in temporary storage.
+     * This method does not need to be either safe or idempotent. Operations that <code>doPut</code> performs can have side
+     * effects for which the user can be held accountable. When using this method, it may be useful to save a copy of the
+     * affected URL in temporary storage.
      *
      * <p>
      * If the HTTP PUT request is incorrectly formatted, <code>doPut</code> returns an HTTP "Bad Request" message.
      *
-     * @param req  the {@link HttpServletRequest} object that contains the request the client made of the servlet
+     * @param req the {@link HttpServletRequest} object that contains the request the client made of the servlet
      *
      * @param resp the {@link HttpServletResponse} object that contains the response the servlet returns to the client
      *
-     * @throws IOException      if an input or output error occurs while the servlet is handling the PUT request
+     * @throws IOException if an input or output error occurs while the servlet is handling the PUT request
      *
      * @throws ServletException if the request for the PUT cannot be handled
      */
@@ -302,18 +299,18 @@ public abstract class HttpServlet extends GenericServlet {
      * The DELETE operation allows a client to remove a document or Web page from the server.
      * 
      * <p>
-     * This method does not need to be either safe or idempotent. Operations requested through DELETE can have side
-     * effects for which users can be held accountable. When using this method, it may be useful to save a copy of the
-     * affected URL in temporary storage.
+     * This method does not need to be either safe or idempotent. Operations requested through DELETE can have side effects
+     * for which users can be held accountable. When using this method, it may be useful to save a copy of the affected URL
+     * in temporary storage.
      *
      * <p>
      * If the HTTP DELETE request is incorrectly formatted, <code>doDelete</code> returns an HTTP "Bad Request" message.
      *
-     * @param req  the {@link HttpServletRequest} object that contains the request the client made of the servlet
+     * @param req the {@link HttpServletRequest} object that contains the request the client made of the servlet
      *
      * @param resp the {@link HttpServletResponse} object that contains the response the servlet returns to the client
      *
-     * @throws IOException      if an input or output error occurs while the servlet is handling the DELETE request
+     * @throws IOException if an input or output error occurs while the servlet is handling the DELETE request
      *
      * @throws ServletException if the request for the DELETE cannot be handled
      */
@@ -352,21 +349,21 @@ public abstract class HttpServlet extends GenericServlet {
     /**
      * Called by the server (via the <code>service</code> method) to allow a servlet to handle a OPTIONS request.
      *
-     * The OPTIONS request determines which HTTP methods the server supports and returns an appropriate header. For
-     * example, if a servlet overrides <code>doGet</code>, this method returns the following header:
+     * The OPTIONS request determines which HTTP methods the server supports and returns an appropriate header. For example,
+     * if a servlet overrides <code>doGet</code>, this method returns the following header:
      *
      * <p>
      * <code>Allow: GET, HEAD, TRACE, OPTIONS</code>
      *
      * <p>
-     * There's no need to override this method unless the servlet implements new HTTP methods, beyond those implemented
-     * by HTTP 1.1.
+     * There's no need to override this method unless the servlet implements new HTTP methods, beyond those implemented by
+     * HTTP 1.1.
      *
-     * @param req  the {@link HttpServletRequest} object that contains the request the client made of the servlet
+     * @param req the {@link HttpServletRequest} object that contains the request the client made of the servlet
      *
      * @param resp the {@link HttpServletResponse} object that contains the response the servlet returns to the client
      *
-     * @throws IOException      if an input or output error occurs while the servlet is handling the OPTIONS request
+     * @throws IOException if an input or output error occurs while the servlet is handling the OPTIONS request
      *
      * @throws ServletException if the request for the OPTIONS cannot be handled
      */
@@ -446,15 +443,15 @@ public abstract class HttpServlet extends GenericServlet {
     /**
      * Called by the server (via the <code>service</code> method) to allow a servlet to handle a TRACE request.
      *
-     * A TRACE returns the headers sent with the TRACE request to the client, so that they can be used in debugging.
-     * There's no need to override this method.
+     * A TRACE returns the headers sent with the TRACE request to the client, so that they can be used in debugging. There's
+     * no need to override this method.
      *
-     * @param req  the {@link HttpServletRequest} object that contains the request the client made of the servlet
+     * @param req the {@link HttpServletRequest} object that contains the request the client made of the servlet
      *
      *
      * @param resp the {@link HttpServletResponse} object that contains the response the servlet returns to the client
      *
-     * @throws IOException      if an input or output error occurs while the servlet is handling the TRACE request
+     * @throws IOException if an input or output error occurs while the servlet is handling the TRACE request
      *
      * @throws ServletException if the request for the TRACE cannot be handled
      */
@@ -488,11 +485,11 @@ public abstract class HttpServlet extends GenericServlet {
      * <code>do</code><i>XXX</i> methods defined in this class. This method is an HTTP-specific version of the
      * {@link jakarta.servlet.Servlet#service} method. There's no need to override this method.
      *
-     * @param req  the {@link HttpServletRequest} object that contains the request the client made of the servlet
+     * @param req the {@link HttpServletRequest} object that contains the request the client made of the servlet
      *
      * @param resp the {@link HttpServletResponse} object that contains the response the servlet returns to the client
      *
-     * @throws IOException      if an input or output error occurs while the servlet is handling the HTTP request
+     * @throws IOException if an input or output error occurs while the servlet is handling the HTTP request
      *
      * @throws ServletException if the HTTP request cannot be handled
      * 
@@ -557,8 +554,8 @@ public abstract class HttpServlet extends GenericServlet {
 
     /*
      * Sets the Last-Modified entity header field, if it has not already been set and if the value is meaningful. Called
-     * before doGet, to ensure that headers are set before response data is written. A subclass might have set this
-     * header already, so we check.
+     * before doGet, to ensure that headers are set before response data is written. A subclass might have set this header
+     * already, so we check.
      */
     private void maybeSetLastModified(HttpServletResponse resp, long lastModified) {
         if (resp.containsHeader(HEADER_LASTMOD))
@@ -574,10 +571,10 @@ public abstract class HttpServlet extends GenericServlet {
      *
      * @param res the {@link HttpServletResponse} object that contains the response the servlet returns to the client
      *
-     * @throws IOException      if an input or output error occurs while the servlet is handling the HTTP request
+     * @throws IOException if an input or output error occurs while the servlet is handling the HTTP request
      *
      * @throws ServletException if the HTTP request cannot be handled or if either parameter is not an instance of its
-     *                          respective {@link HttpServletRequest} or {@link HttpServletResponse} counterparts.
+     * respective {@link HttpServletRequest} or {@link HttpServletResponse} counterparts.
      * 
      * @see jakarta.servlet.Servlet#service
      */

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -18,11 +18,11 @@
 
 package jakarta.servlet.http;
 
-import java.io.IOException;
-import java.util.*;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
+import java.io.IOException;
+import java.util.*;
 
 /**
  *
@@ -58,16 +58,16 @@ public interface HttpServletRequest extends ServletRequest {
     public static final String DIGEST_AUTH = "DIGEST";
 
     /**
-     * Returns the name of the authentication scheme used to protect the servlet. All servlet containers support basic,
-     * form and client certificate authentication, and may additionally support digest authentication. If the servlet is
-     * not authenticated <code>null</code> is returned.
+     * Returns the name of the authentication scheme used to protect the servlet. All servlet containers support basic, form
+     * and client certificate authentication, and may additionally support digest authentication. If the servlet is not
+     * authenticated <code>null</code> is returned.
      *
      * <p>
      * Same as the value of the CGI variable AUTH_TYPE.
      *
-     * @return one of the static members BASIC_AUTH, FORM_AUTH, CLIENT_CERT_AUTH, DIGEST_AUTH (suitable for ==
-     *         comparison) or the container-specific string indicating the authentication scheme, or <code>null</code>
-     *         if the request was not authenticated.
+     * @return one of the static members BASIC_AUTH, FORM_AUTH, CLIENT_CERT_AUTH, DIGEST_AUTH (suitable for == comparison)
+     * or the container-specific string indicating the authentication scheme, or <code>null</code> if the request was not
+     * authenticated.
      */
     public String getAuthType();
 
@@ -75,53 +75,50 @@ public interface HttpServletRequest extends ServletRequest {
      * Returns an array containing all of the <code>Cookie</code> objects the client sent with this request. This method
      * returns <code>null</code> if no cookies were sent.
      *
-     * @return an array of all the <code>Cookies</code> included with this request, or <code>null</code> if the request
-     *         has no cookies
+     * @return an array of all the <code>Cookies</code> included with this request, or <code>null</code> if the request has
+     * no cookies
      */
     public Cookie[] getCookies();
 
     /**
-     * Returns the value of the specified request header as a <code>long</code> value that represents a
-     * <code>Date</code> object. Use this method with headers that contain dates, such as
-     * <code>If-Modified-Since</code>.
+     * Returns the value of the specified request header as a <code>long</code> value that represents a <code>Date</code>
+     * object. Use this method with headers that contain dates, such as <code>If-Modified-Since</code>.
      *
      * <p>
-     * The date is returned as the number of milliseconds since January 1, 1970 GMT. The header name is case
-     * insensitive.
+     * The date is returned as the number of milliseconds since January 1, 1970 GMT. The header name is case insensitive.
      *
      * <p>
-     * If the request did not have a header of the specified name, this method returns -1. If the header can't be
-     * converted to a date, the method throws an <code>IllegalArgumentException</code>.
+     * If the request did not have a header of the specified name, this method returns -1. If the header can't be converted
+     * to a date, the method throws an <code>IllegalArgumentException</code>.
      *
      * @param name a <code>String</code> specifying the name of the header
      *
      * @return a <code>long</code> value representing the date specified in the header expressed as the number of
-     *         milliseconds since January 1, 1970 GMT, or -1 if the named header was not included with the request
+     * milliseconds since January 1, 1970 GMT, or -1 if the named header was not included with the request
      *
      * @exception IllegalArgumentException If the header value can't be converted to a date
      */
     public long getDateHeader(String name);
 
     /**
-     * Returns the value of the specified request header as a <code>String</code>. If the request did not include a
-     * header of the specified name, this method returns <code>null</code>. If there are multiple headers with the same
-     * name, this method returns the first head in the request. The header name is case insensitive. You can use this
-     * method with any request header.
+     * Returns the value of the specified request header as a <code>String</code>. If the request did not include a header
+     * of the specified name, this method returns <code>null</code>. If there are multiple headers with the same name, this
+     * method returns the first head in the request. The header name is case insensitive. You can use this method with any
+     * request header.
      *
      * @param name a <code>String</code> specifying the header name
      *
-     * @return a <code>String</code> containing the value of the requested header, or <code>null</code> if the request
-     *         does not have a header of that name
+     * @return a <code>String</code> containing the value of the requested header, or <code>null</code> if the request does
+     * not have a header of that name
      */
     public String getHeader(String name);
 
     /**
-     * Returns all the values of the specified request header as an <code>Enumeration</code> of <code>String</code>
-     * objects.
+     * Returns all the values of the specified request header as an <code>Enumeration</code> of <code>String</code> objects.
      *
      * <p>
-     * Some headers, such as <code>Accept-Language</code> can be sent by clients as several headers each with a
-     * different value rather than sending the header as a comma separated list.
+     * Some headers, such as <code>Accept-Language</code> can be sent by clients as several headers each with a different
+     * value rather than sending the header as a comma separated list.
      *
      * <p>
      * If the request did not include any headers of the specified name, this method returns an empty
@@ -129,9 +126,9 @@ public interface HttpServletRequest extends ServletRequest {
      *
      * @param name a <code>String</code> specifying the header name
      *
-     * @return an <code>Enumeration</code> containing the values of the requested header. If the request does not have
-     *         any headers of that name return an empty enumeration. If the container does not allow access to header
-     *         information, return null
+     * @return an <code>Enumeration</code> containing the values of the requested header. If the request does not have any
+     * headers of that name return an empty enumeration. If the container does not allow access to header information,
+     * return null
      */
     public Enumeration<String> getHeaders(String name);
 
@@ -140,26 +137,25 @@ public interface HttpServletRequest extends ServletRequest {
      * returns an empty enumeration.
      *
      * <p>
-     * Some servlet containers do not allow servlets to access headers using this method, in which case this method
-     * returns <code>null</code>
+     * Some servlet containers do not allow servlets to access headers using this method, in which case this method returns
+     * <code>null</code>
      *
      * @return an enumeration of all the header names sent with this request; if the request has no headers, an empty
-     *         enumeration; if the servlet container does not allow servlets to use this method, <code>null</code>
+     * enumeration; if the servlet container does not allow servlets to use this method, <code>null</code>
      */
     public Enumeration<String> getHeaderNames();
 
     /**
-     * Returns the value of the specified request header as an <code>int</code>. If the request does not have a header
-     * of the specified name, this method returns -1. If the header cannot be converted to an integer, this method
-     * throws a <code>NumberFormatException</code>.
+     * Returns the value of the specified request header as an <code>int</code>. If the request does not have a header of
+     * the specified name, this method returns -1. If the header cannot be converted to an integer, this method throws a
+     * <code>NumberFormatException</code>.
      *
      * <p>
      * The header name is case insensitive.
      *
      * @param name a <code>String</code> specifying the name of a request header
      *
-     * @return an integer expressing the value of the request header or -1 if the request doesn't have a header of this
-     *         name
+     * @return an integer expressing the value of the request header or -1 if the request doesn't have a header of this name
      *
      * @exception NumberFormatException If the header value can't be converted to an <code>int</code>
      */
@@ -191,8 +187,8 @@ public interface HttpServletRequest extends ServletRequest {
      * </p>
      * 
      * @implSpec The default implementation returns a {@code
-     * HttpServletMapping} that returns the empty string for the match value, pattern and servlet name and {@code null}
-     *           for the match type.
+     * HttpServletMapping} that returns the empty string for the match value, pattern and servlet name and {@code null} for
+     * the match type.
      *
      * @return An instance of {@code HttpServletMapping} describing the manner in which the current request was invoked.
      * 
@@ -239,8 +235,8 @@ public interface HttpServletRequest extends ServletRequest {
     public String getMethod();
 
     /**
-     * Returns any extra path information associated with the URL the client sent when it made this request. The extra
-     * path information follows the servlet path but precedes the query string and will start with a "/" character.
+     * Returns any extra path information associated with the URL the client sent when it made this request. The extra path
+     * information follows the servlet path but precedes the query string and will start with a "/" character.
      *
      * <p>
      * This method returns <code>null</code> if there was no extra path information.
@@ -248,37 +244,37 @@ public interface HttpServletRequest extends ServletRequest {
      * <p>
      * Same as the value of the CGI variable PATH_INFO.
      *
-     * @return a <code>String</code>, decoded by the web container, specifying extra path information that comes after
-     *         the servlet path but before the query string in the request URL; or <code>null</code> if the URL does not
-     *         have any extra path information
+     * @return a <code>String</code>, decoded by the web container, specifying extra path information that comes after the
+     * servlet path but before the query string in the request URL; or <code>null</code> if the URL does not have any extra
+     * path information
      */
     public String getPathInfo();
 
     /**
-     * Returns any extra path information after the servlet name but before the query string, and translates it to a
-     * real path. Same as the value of the CGI variable PATH_TRANSLATED.
+     * Returns any extra path information after the servlet name but before the query string, and translates it to a real
+     * path. Same as the value of the CGI variable PATH_TRANSLATED.
      *
      * <p>
-     * If the URL does not have any extra path information, this method returns <code>null</code> or the servlet
-     * container cannot translate the virtual path to a real path for any reason (such as when the web application is
-     * executed from an archive).
+     * If the URL does not have any extra path information, this method returns <code>null</code> or the servlet container
+     * cannot translate the virtual path to a real path for any reason (such as when the web application is executed from an
+     * archive).
      *
      * The web container does not decode this string.
      *
-     * @return a <code>String</code> specifying the real path, or <code>null</code> if the URL does not have any extra
-     *         path information
+     * @return a <code>String</code> specifying the real path, or <code>null</code> if the URL does not have any extra path
+     * information
      */
     public String getPathTranslated();
 
     /**
-     * Instantiates a new instance of {@link PushBuilder} for issuing server push responses from the current request.
-     * This method returns null if the current connection does not support server push, or server push has been disabled
-     * by the client via a {@code SETTINGS_ENABLE_PUSH} settings frame value of {@code 0} (zero).
+     * Instantiates a new instance of {@link PushBuilder} for issuing server push responses from the current request. This
+     * method returns null if the current connection does not support server push, or server push has been disabled by the
+     * client via a {@code SETTINGS_ENABLE_PUSH} settings frame value of {@code 0} (zero).
      *
      * @implSpec The default implementation returns null.
      *
      * @return a {@link PushBuilder} for issuing server push responses from the current request, or null if push is not
-     *         supported
+     * supported
      *
      * @since Servlet 4.0
      */
@@ -287,13 +283,13 @@ public interface HttpServletRequest extends ServletRequest {
     }
 
     /**
-     * Returns the portion of the request URI that indicates the context of the request. The context path always comes
-     * first in a request URI. The path starts with a "/" character but does not end with a "/" character. For servlets
-     * in the default (root) context, this method returns "". The container does not decode this string.
+     * Returns the portion of the request URI that indicates the context of the request. The context path always comes first
+     * in a request URI. The path starts with a "/" character but does not end with a "/" character. For servlets in the
+     * default (root) context, this method returns "". The container does not decode this string.
      *
      * <p>
-     * It is possible that a servlet container may match a context by more than one context path. In such cases this
-     * method will return the actual context path used by the request and it may differ from the path returned by the
+     * It is possible that a servlet container may match a context by more than one context path. In such cases this method
+     * will return the actual context path used by the request and it may differ from the path returned by the
      * {@link jakarta.servlet.ServletContext#getContextPath()} method. The context path returned by
      * {@link jakarta.servlet.ServletContext#getContextPath()} should be considered as the prime or preferred context path
      * of the application.
@@ -305,67 +301,67 @@ public interface HttpServletRequest extends ServletRequest {
     public String getContextPath();
 
     /**
-     * Returns the query string that is contained in the request URL after the path. This method returns
-     * <code>null</code> if the URL does not have a query string. Same as the value of the CGI variable QUERY_STRING.
+     * Returns the query string that is contained in the request URL after the path. This method returns <code>null</code>
+     * if the URL does not have a query string. Same as the value of the CGI variable QUERY_STRING.
      *
-     * @return a <code>String</code> containing the query string or <code>null</code> if the URL contains no query
-     *         string. The value is not decoded by the container.
+     * @return a <code>String</code> containing the query string or <code>null</code> if the URL contains no query string.
+     * The value is not decoded by the container.
      */
     public String getQueryString();
 
     /**
-     * Returns the login of the user making this request, if the user has been authenticated, or <code>null</code> if
-     * the user has not been authenticated. Whether the user name is sent with each subsequent request depends on the
-     * browser and type of authentication. Same as the value of the CGI variable REMOTE_USER.
+     * Returns the login of the user making this request, if the user has been authenticated, or <code>null</code> if the
+     * user has not been authenticated. Whether the user name is sent with each subsequent request depends on the browser
+     * and type of authentication. Same as the value of the CGI variable REMOTE_USER.
      *
-     * @return a <code>String</code> specifying the login of the user making this request, or <code>null</code> if the
-     *         user login is not known
+     * @return a <code>String</code> specifying the login of the user making this request, or <code>null</code> if the user
+     * login is not known
      */
     public String getRemoteUser();
 
     /**
-     * Returns a boolean indicating whether the authenticated user is included in the specified logical "role". Roles
-     * and role membership can be defined using deployment descriptors. If the user has not been authenticated, the
-     * method returns <code>false</code>.
+     * Returns a boolean indicating whether the authenticated user is included in the specified logical "role". Roles and
+     * role membership can be defined using deployment descriptors. If the user has not been authenticated, the method
+     * returns <code>false</code>.
      *
      * <p>
      * The role name "*" should never be used as an argument in calling <code>isUserInRole</code>. Any call to
-     * <code>isUserInRole</code> with "*" must return false. If the role-name of the security-role to be tested is "**",
-     * and the application has NOT declared an application security-role with role-name "**", <code>isUserInRole</code>
-     * must only return true if the user has been authenticated; that is, only when {@link #getRemoteUser} and
+     * <code>isUserInRole</code> with "*" must return false. If the role-name of the security-role to be tested is "**", and
+     * the application has NOT declared an application security-role with role-name "**", <code>isUserInRole</code> must
+     * only return true if the user has been authenticated; that is, only when {@link #getRemoteUser} and
      * {@link #getUserPrincipal} would both return a non-null value. Otherwise, the container must check the user for
      * membership in the application role.
      *
      * @param role a <code>String</code> specifying the name of the role
      *
      * @return a <code>boolean</code> indicating whether the user making this request belongs to a given role;
-     *         <code>false</code> if the user has not been authenticated
+     * <code>false</code> if the user has not been authenticated
      */
     public boolean isUserInRole(String role);
 
     /**
-     * Returns a <code>java.security.Principal</code> object containing the name of the current authenticated user. If
-     * the user has not been authenticated, the method returns <code>null</code>.
+     * Returns a <code>java.security.Principal</code> object containing the name of the current authenticated user. If the
+     * user has not been authenticated, the method returns <code>null</code>.
      *
-     * @return a <code>java.security.Principal</code> containing the name of the user making this request;
-     *         <code>null</code> if the user has not been authenticated
+     * @return a <code>java.security.Principal</code> containing the name of the user making this request; <code>null</code>
+     * if the user has not been authenticated
      */
     public java.security.Principal getUserPrincipal();
 
     /**
-     * Returns the session ID specified by the client. This may not be the same as the ID of the current valid session
-     * for this request. If the client did not specify a session ID, this method returns <code>null</code>.
+     * Returns the session ID specified by the client. This may not be the same as the ID of the current valid session for
+     * this request. If the client did not specify a session ID, this method returns <code>null</code>.
      *
      * @return a <code>String</code> specifying the session ID, or <code>null</code> if the request did not specify a
-     *         session ID
+     * session ID
      *
      * @see #isRequestedSessionIdValid
      */
     public String getRequestedSessionId();
 
     /**
-     * Returns the part of this request's URL from the protocol name up to the query string in the first line of the
-     * HTTP request. The web container does not decode this String. For example:
+     * Returns the part of this request's URL from the protocol name up to the query string in the first line of the HTTP
+     * request. The web container does not decode this String. For example:
      *
      * <table summary="Examples of Returned Values">
      * <tr align=left>
@@ -400,12 +396,12 @@ public interface HttpServletRequest extends ServletRequest {
      *
      * <p>
      * If this request has been forwarded using {@link jakarta.servlet.RequestDispatcher#forward}, the server path in the
-     * reconstructed URL must reflect the path used to obtain the RequestDispatcher, and not the server path specified
-     * by the client.
+     * reconstructed URL must reflect the path used to obtain the RequestDispatcher, and not the server path specified by
+     * the client.
      *
      * <p>
-     * Because this method returns a <code>StringBuffer</code>, not a string, you can modify the URL easily, for
-     * example, to append query parameters.
+     * Because this method returns a <code>StringBuffer</code>, not a string, you can modify the URL easily, for example, to
+     * append query parameters.
      *
      * <p>
      * This method is useful for creating redirect messages and for reporting errors.
@@ -416,16 +412,15 @@ public interface HttpServletRequest extends ServletRequest {
 
     /**
      * Returns the part of this request's URL that calls the servlet. This path starts with a "/" character and includes
-     * either the servlet name or a path to the servlet, but does not include any extra path information or a query
-     * string. Same as the value of the CGI variable SCRIPT_NAME.
+     * either the servlet name or a path to the servlet, but does not include any extra path information or a query string.
+     * Same as the value of the CGI variable SCRIPT_NAME.
      *
      * <p>
-     * This method will return an empty string ("") if the servlet used to process this request was matched using the
-     * "/*" pattern.
+     * This method will return an empty string ("") if the servlet used to process this request was matched using the "/*"
+     * pattern.
      *
-     * @return a <code>String</code> containing the name or path of the servlet being called, as specified in the
-     *         request URL, decoded, or an empty string if the servlet used to process the request is matched using the
-     *         "/*" pattern.
+     * @return a <code>String</code> containing the name or path of the servlet being called, as specified in the request
+     * URL, decoded, or an empty string if the servlet used to process the request is matched using the "/*" pattern.
      */
     public String getServletPath();
 
@@ -438,15 +433,15 @@ public interface HttpServletRequest extends ServletRequest {
      * returns <code>null</code>.
      *
      * <p>
-     * To make sure the session is properly maintained, you must call this method before the response is committed. If
-     * the container is using cookies to maintain session integrity and is asked to create a new session when the
-     * response is committed, an IllegalStateException is thrown.
+     * To make sure the session is properly maintained, you must call this method before the response is committed. If the
+     * container is using cookies to maintain session integrity and is asked to create a new session when the response is
+     * committed, an IllegalStateException is thrown.
      *
-     * @param create <code>true</code> to create a new session for this request if necessary; <code>false</code> to
-     *               return <code>null</code> if there's no current session
+     * @param create <code>true</code> to create a new session for this request if necessary; <code>false</code> to return
+     * <code>null</code> if there's no current session
      *
      * @return the <code>HttpSession</code> associated with this request or <code>null</code> if <code>create</code> is
-     *         <code>false</code> and the request has no valid session
+     * <code>false</code> and the request has no valid session
      *
      * @see #getSession()
      */
@@ -479,7 +474,7 @@ public interface HttpServletRequest extends ServletRequest {
      * If the client did not specify any session ID, this method returns <code>false</code>.
      *
      * @return <code>true</code> if this request has an id for a valid session in the current session context;
-     *         <code>false</code> otherwise
+     * <code>false</code> otherwise
      *
      * @see #getRequestedSessionId
      * @see #getSession
@@ -493,7 +488,7 @@ public interface HttpServletRequest extends ServletRequest {
      * </p>
      *
      * @return <code>true</code> if the session ID was conveyed to the server an an HTTP cookie; otherwise,
-     *         <code>false</code>
+     * <code>false</code>
      *
      * @see #getSession
      */
@@ -505,7 +500,7 @@ public interface HttpServletRequest extends ServletRequest {
      * </p>
      *
      * @return <code>true</code> if the session ID was conveyed to the server as part of a URL; otherwise,
-     *         <code>false</code>
+     * <code>false</code>
      *
      * @see #getSession
      */
@@ -515,14 +510,14 @@ public interface HttpServletRequest extends ServletRequest {
      * @deprecated As of Version 2.1 of the Java Servlet API, use {@link #isRequestedSessionIdFromURL} instead.
      *
      * @return <code>true</code> if the session ID was conveyed to the server as part of a URL; otherwise,
-     *         <code>false</code>
+     * <code>false</code>
      */
     @Deprecated
     public boolean isRequestedSessionIdFromUrl();
 
     /**
-     * Use the container login mechanism configured for the <code>ServletContext</code> to authenticate the user making
-     * this request.
+     * Use the container login mechanism configured for the <code>ServletContext</code> to authenticate the user making this
+     * request.
      *
      * <p>
      * This method may modify and commit the argument <code>HttpServletResponse</code>.
@@ -530,19 +525,17 @@ public interface HttpServletRequest extends ServletRequest {
      * @param response The <code>HttpServletResponse</code> associated with this <code>HttpServletRequest</code>
      *
      * @return <code>true</code> when non-null values were or have been established as the values returned by
-     *         <code>getUserPrincipal</code>, <code>getRemoteUser</code>, and <code>getAuthType</code>. Return
-     *         <code>false</code> if authentication is incomplete and the underlying login mechanism has committed, in
-     *         the response, the message (e.g., challenge) and HTTP status code to be returned to the user.
+     * <code>getUserPrincipal</code>, <code>getRemoteUser</code>, and <code>getAuthType</code>. Return <code>false</code> if
+     * authentication is incomplete and the underlying login mechanism has committed, in the response, the message (e.g.,
+     * challenge) and HTTP status code to be returned to the user.
      *
-     * @throws IOException           if an input or output error occurred while reading from this request or writing to
-     *                               the given response
+     * @throws IOException if an input or output error occurred while reading from this request or writing to the given
+     * response
      *
-     * @throws IllegalStateException if the login mechanism attempted to modify the response and it was already
-     *                               committed
+     * @throws IllegalStateException if the login mechanism attempted to modify the response and it was already committed
      *
-     * @throws ServletException      if the authentication failed and the caller is responsible for handling the error
-     *                               (i.e., the underlying login mechanism did NOT establish the message and HTTP status
-     *                               code to be returned to the user)
+     * @throws ServletException if the authentication failed and the caller is responsible for handling the error (i.e., the
+     * underlying login mechanism did NOT establish the message and HTTP status code to be returned to the user)
      *
      * @since Servlet 3.0
      */
@@ -554,8 +547,8 @@ public interface HttpServletRequest extends ServletRequest {
      *
      * <p>
      * This method returns without throwing a <code>ServletException</code> when the login mechanism configured for the
-     * <code>ServletContext</code> supports username password validation, and when, at the time of the call to login,
-     * the identity of the caller of the request had not been established (i.e, all of <code>getUserPrincipal</code>,
+     * <code>ServletContext</code> supports username password validation, and when, at the time of the call to login, the
+     * identity of the caller of the request had not been established (i.e, all of <code>getUserPrincipal</code>,
      * <code>getRemoteUser</code>, and <code>getAuthType</code> return null), and when validation of the provided
      * credentials is successful. Otherwise, this method throws a <code>ServletException</code> as described below.
      *
@@ -567,17 +560,17 @@ public interface HttpServletRequest extends ServletRequest {
      *
      * @param password The password <code>String</code> corresponding to the identified user.
      *
-     * @exception ServletException if the configured login mechanism does not support username password authentication,
-     *                             or if a non-null caller identity had already been established (prior to the call to
-     *                             login), or if validation of the provided username and password fails.
+     * @exception ServletException if the configured login mechanism does not support username password authentication, or
+     * if a non-null caller identity had already been established (prior to the call to login), or if validation of the
+     * provided username and password fails.
      *
      * @since Servlet 3.0
      */
     public void login(String username, String password) throws ServletException;
 
     /**
-     * Establish <code>null</code> as the value returned when <code>getUserPrincipal</code>, <code>getRemoteUser</code>,
-     * and <code>getAuthType</code> is called on the request.
+     * Establish <code>null</code> as the value returned when <code>getUserPrincipal</code>, <code>getRemoteUser</code>, and
+     * <code>getAuthType</code> is called on the request.
      *
      * @exception ServletException if logout fails
      *
@@ -586,27 +579,24 @@ public interface HttpServletRequest extends ServletRequest {
     public void logout() throws ServletException;
 
     /**
-     * Gets all the {@link Part} components of this request, provided that it is of type
-     * <code>multipart/form-data</code>.
+     * Gets all the {@link Part} components of this request, provided that it is of type <code>multipart/form-data</code>.
      *
      * <p>
-     * If this request is of type <code>multipart/form-data</code>, but does not contain any <code>Part</code>
-     * components, the returned <code>Collection</code> will be empty.
+     * If this request is of type <code>multipart/form-data</code>, but does not contain any <code>Part</code> components,
+     * the returned <code>Collection</code> will be empty.
      *
      * <p>
      * Any changes to the returned <code>Collection</code> must not affect this <code>HttpServletRequest</code>.
      *
      * @return a (possibly empty) <code>Collection</code> of the <code>Part</code> components of this request
      *
-     * @throws IOException           if an I/O error occurred during the retrieval of the {@link Part} components of
-     *                               this request
+     * @throws IOException if an I/O error occurred during the retrieval of the {@link Part} components of this request
      *
-     * @throws ServletException      if this request is not of type <code>multipart/form-data</code>
+     * @throws ServletException if this request is not of type <code>multipart/form-data</code>
      *
      * @throws IllegalStateException if the request body is larger than <code>maxRequestSize</code>, or any
-     *                               <code>Part</code> in the request is larger than <code>maxFileSize</code>, or there
-     *                               is no <code>@MultipartConfig</code> or <code>multipart-config</code> in deployment
-     *                               descriptors
+     * <code>Part</code> in the request is larger than <code>maxFileSize</code>, or there is no
+     * <code>@MultipartConfig</code> or <code>multipart-config</code> in deployment descriptors
      *
      * @see jakarta.servlet.annotation.MultipartConfig#maxFileSize
      * @see jakarta.servlet.annotation.MultipartConfig#maxRequestSize
@@ -621,14 +611,13 @@ public interface HttpServletRequest extends ServletRequest {
      * @param name the name of the requested <code>Part</code>
      *
      * @return The <code>Part</code> with the given name, or <code>null</code> if this request is of type
-     *         <code>multipart/form-data</code>, but does not contain the requested <code>Part</code>
+     * <code>multipart/form-data</code>, but does not contain the requested <code>Part</code>
      *
-     * @throws IOException           if an I/O error occurred during the retrieval of the requested <code>Part</code>
-     * @throws ServletException      if this request is not of type <code>multipart/form-data</code>
+     * @throws IOException if an I/O error occurred during the retrieval of the requested <code>Part</code>
+     * @throws ServletException if this request is not of type <code>multipart/form-data</code>
      * @throws IllegalStateException if the request body is larger than <code>maxRequestSize</code>, or any
-     *                               <code>Part</code> in the request is larger than <code>maxFileSize</code>, or there
-     *                               is no <code>@MultipartConfig</code> or <code>multipart-config</code> in deployment
-     *                               descriptors
+     * <code>Part</code> in the request is larger than <code>maxFileSize</code>, or there is no
+     * <code>@MultipartConfig</code> or <code>multipart-config</code> in deployment descriptors
      *
      * @see jakarta.servlet.annotation.MultipartConfig#maxFileSize
      * @see jakarta.servlet.annotation.MultipartConfig#maxRequestSize
@@ -638,16 +627,16 @@ public interface HttpServletRequest extends ServletRequest {
     public Part getPart(String name) throws IOException, ServletException;
 
     /**
-     * Creates an instance of <code>HttpUpgradeHandler</code> for a given class and uses it for the http protocol
-     * upgrade processing.
+     * Creates an instance of <code>HttpUpgradeHandler</code> for a given class and uses it for the http protocol upgrade
+     * processing.
      *
-     * @param              <T> The {@code Class}, which extends {@link HttpUpgradeHandler}, of the {@code handlerClass}.
+     * @param <T> The {@code Class}, which extends {@link HttpUpgradeHandler}, of the {@code handlerClass}.
      * 
      * @param handlerClass The <code>HttpUpgradeHandler</code> class used for the upgrade.
      *
      * @return an instance of the <code>HttpUpgradeHandler</code>
      *
-     * @exception IOException      if an I/O error occurred during the upgrade
+     * @exception IOException if an I/O error occurred during the upgrade
      * @exception ServletException if the given <code>handlerClass</code> fails to be instantiated
      *
      * @see jakarta.servlet.http.HttpUpgradeHandler
@@ -666,15 +655,15 @@ public interface HttpServletRequest extends ServletRequest {
      * </p>
      * 
      * <p>
-     * {@link #isTrailerFieldsReady()} should be called first to determine if it is safe to call this method without
-     * causing an exception.
+     * {@link #isTrailerFieldsReady()} should be called first to determine if it is safe to call this method without causing
+     * an exception.
      * </p>
      *
      * @implSpec The default implementation returns an empty map.
      * 
      * @return A map of trailer fields in which all the keys are in lowercase, regardless of the case they had at the
-     *         protocol level. If there are no trailer fields, yet {@link #isTrailerFieldsReady} is returning true, the
-     *         empty map is returned.
+     * protocol level. If there are no trailer fields, yet {@link #isTrailerFieldsReady} is returning true, the empty map is
+     * returned.
      *
      * @throws IllegalStateException if {@link #isTrailerFieldsReady()} is false
      *
@@ -691,10 +680,10 @@ public interface HttpServletRequest extends ServletRequest {
      * underlying protocol (such as HTTP 1.0) does not supports the trailer fields, or the request is not in chunked
      * encoding in HTTP 1.1. And the method also returns true if both of the following conditions are satisfied:
      * <ol type="a">
-     * <li>the application has read all the request data and an EOF indication has been returned from the
-     * {@link #getReader} or {@link #getInputStream}.
-     * <li>all the trailer fields sent by the client have been received. Note that it is possible that the client has
-     * sent no trailer fields.
+     * <li>the application has read all the request data and an EOF indication has been returned from the {@link #getReader}
+     * or {@link #getInputStream}.
+     * <li>all the trailer fields sent by the client have been received. Note that it is possible that the client has sent
+     * no trailer fields.
      * </ol>
      *
      * @implSpec The default implementation returns false.

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequestWrapper.java
@@ -18,10 +18,10 @@
 
 package jakarta.servlet.http;
 
-import java.io.IOException;
-import java.util.*;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequestWrapper;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Provides a convenient implementation of the HttpServletRequest interface that can be subclassed by developers wishing

--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponse.java
@@ -18,11 +18,11 @@
 
 package jakarta.servlet.http;
 
+import jakarta.servlet.ServletResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
-import jakarta.servlet.ServletResponse;
 
 /**
  *
@@ -58,10 +58,9 @@ public interface HttpServletResponse extends ServletResponse {
     public boolean containsHeader(String name);
 
     /**
-     * Encodes the specified URL by including the session ID, or, if encoding is not needed, returns the URL unchanged.
-     * The implementation of this method includes the logic to determine whether the session ID needs to be encoded in
-     * the URL. For example, if the browser supports cookies, or session tracking is turned off, URL encoding is
-     * unnecessary.
+     * Encodes the specified URL by including the session ID, or, if encoding is not needed, returns the URL unchanged. The
+     * implementation of this method includes the logic to determine whether the session ID needs to be encoded in the URL.
+     * For example, if the browser supports cookies, or session tracking is turned off, URL encoding is unnecessary.
      * 
      * <p>
      * For robust session tracking, all URLs emitted by a servlet should be run through this method. Otherwise, URL
@@ -77,11 +76,11 @@ public interface HttpServletResponse extends ServletResponse {
     public String encodeURL(String url);
 
     /**
-     * Encodes the specified URL for use in the <code>sendRedirect</code> method or, if encoding is not needed, returns
-     * the URL unchanged. The implementation of this method includes the logic to determine whether the session ID needs
-     * to be encoded in the URL. For example, if the browser supports cookies, or session tracking is turned off, URL
-     * encoding is unnecessary. Because the rules for making this determination can differ from those used to decide
-     * whether to encode a normal link, this method is separated from the <code>encodeURL</code> method.
+     * Encodes the specified URL for use in the <code>sendRedirect</code> method or, if encoding is not needed, returns the
+     * URL unchanged. The implementation of this method includes the logic to determine whether the session ID needs to be
+     * encoded in the URL. For example, if the browser supports cookies, or session tracking is turned off, URL encoding is
+     * unnecessary. Because the rules for making this determination can differ from those used to decide whether to encode a
+     * normal link, this method is separated from the <code>encodeURL</code> method.
      * 
      * <p>
      * All URLs sent to the <code>HttpServletResponse.sendRedirect</code> method should be run through this method.
@@ -122,12 +121,11 @@ public interface HttpServletResponse extends ServletResponse {
     /**
      * <p>
      * Sends an error response to the client using the specified status and clears the buffer. The server defaults to
-     * creating the response to look like an HTML-formatted server error page containing the specified message, setting
-     * the content type to "text/html". The caller is <strong>not</strong> responsible for escaping or re-encoding the
-     * message to ensure it is safe with respect to the current response encoding and content type. This aspect of
-     * safety is the responsibility of the container, as it is generating the error page containing the message. The
-     * server will preserve cookies and may clear or update any headers needed to serve the error page as a valid
-     * response.
+     * creating the response to look like an HTML-formatted server error page containing the specified message, setting the
+     * content type to "text/html". The caller is <strong>not</strong> responsible for escaping or re-encoding the message
+     * to ensure it is safe with respect to the current response encoding and content type. This aspect of safety is the
+     * responsibility of the container, as it is generating the error page containing the message. The server will preserve
+     * cookies and may clear or update any headers needed to serve the error page as a valid response.
      * </p>
      *
      * <p>
@@ -136,12 +134,12 @@ public interface HttpServletResponse extends ServletResponse {
      * </p>
      *
      * <p>
-     * If the response has already been committed, this method throws an IllegalStateException. After using this method,
-     * the response should be considered to be committed and should not be written to.
+     * If the response has already been committed, this method throws an IllegalStateException. After using this method, the
+     * response should be considered to be committed and should not be written to.
      *
-     * @param sc  the error status code
+     * @param sc the error status code
      * @param msg the descriptive message
-     * @exception IOException           If an input or output exception occurs
+     * @exception IOException If an input or output exception occurs
      * @exception IllegalStateException If the response was committed
      */
     public void sendError(int sc, String msg) throws IOException;
@@ -156,42 +154,41 @@ public interface HttpServletResponse extends ServletResponse {
      * will be served back the error page
      * 
      * <p>
-     * If the response has already been committed, this method throws an IllegalStateException. After using this method,
-     * the response should be considered to be committed and should not be written to.
+     * If the response has already been committed, this method throws an IllegalStateException. After using this method, the
+     * response should be considered to be committed and should not be written to.
      *
      * @param sc the error status code
-     * @exception IOException           If an input or output exception occurs
+     * @exception IOException If an input or output exception occurs
      * @exception IllegalStateException If the response was committed before this method call
      */
     public void sendError(int sc) throws IOException;
 
     /**
-     * Sends a temporary redirect response to the client using the specified redirect location URL and clears the
-     * buffer. The buffer will be replaced with the data set by this method. Calling this method sets the status code to
-     * {@link #SC_FOUND} 302 (Found). This method can accept relative URLs;the servlet container must convert the
-     * relative URL to an absolute URL before sending the response to the client. If the location is relative without a
-     * leading '/' the container interprets it as relative to the current request URI. If the location is relative with
-     * a leading '/' the container interprets it as relative to the servlet container root. If the location is relative
-     * with two leading '/' the container interprets it as a network-path reference (see
-     * <a href="http://www.ietf.org/rfc/rfc3986.txt"> RFC 3986: Uniform Resource Identifier (URI): Generic Syntax</a>,
-     * section 4.2 &quot;Relative Reference&quot;).
+     * Sends a temporary redirect response to the client using the specified redirect location URL and clears the buffer.
+     * The buffer will be replaced with the data set by this method. Calling this method sets the status code to
+     * {@link #SC_FOUND} 302 (Found). This method can accept relative URLs;the servlet container must convert the relative
+     * URL to an absolute URL before sending the response to the client. If the location is relative without a leading '/'
+     * the container interprets it as relative to the current request URI. If the location is relative with a leading '/'
+     * the container interprets it as relative to the servlet container root. If the location is relative with two leading
+     * '/' the container interprets it as a network-path reference (see <a href="http://www.ietf.org/rfc/rfc3986.txt"> RFC
+     * 3986: Uniform Resource Identifier (URI): Generic Syntax</a>, section 4.2 &quot;Relative Reference&quot;).
      *
      * <p>
-     * If the response has already been committed, this method throws an IllegalStateException. After using this method,
-     * the response should be considered to be committed and should not be written to.
+     * If the response has already been committed, this method throws an IllegalStateException. After using this method, the
+     * response should be considered to be committed and should not be written to.
      *
      * @param location the redirect location URL
-     * @exception IOException           If an input or output exception occurs
-     * @exception IllegalStateException If the response was committed or if a partial URL is given and cannot be
-     *                                  converted into a valid URL
+     * @exception IOException If an input or output exception occurs
+     * @exception IllegalStateException If the response was committed or if a partial URL is given and cannot be converted
+     * into a valid URL
      */
     public void sendRedirect(String location) throws IOException;
 
     /**
      * 
-     * Sets a response header with the given name and date-value. The date is specified in terms of milliseconds since
-     * the epoch. If the header had already been set, the new value overwrites the previous one. The
-     * <code>containsHeader</code> method can be used to test for the presence of a header before setting its value.
+     * Sets a response header with the given name and date-value. The date is specified in terms of milliseconds since the
+     * epoch. If the header had already been set, the new value overwrites the previous one. The <code>containsHeader</code>
+     * method can be used to test for the presence of a header before setting its value.
      * 
      * @param name the name of the header to set
      * @param date the assigned date value
@@ -203,8 +200,8 @@ public interface HttpServletResponse extends ServletResponse {
 
     /**
      * 
-     * Adds a response header with the given name and date-value. The date is specified in terms of milliseconds since
-     * the epoch. This method allows response headers to have multiple values.
+     * Adds a response header with the given name and date-value. The date is specified in terms of milliseconds since the
+     * epoch. This method allows response headers to have multiple values.
      * 
      * @param name the name of the header to set
      * @param date the additional date value
@@ -215,13 +212,13 @@ public interface HttpServletResponse extends ServletResponse {
 
     /**
      *
-     * Sets a response header with the given name and value. If the header had already been set, the new value
-     * overwrites the previous one. The <code>containsHeader</code> method can be used to test for the presence of a
-     * header before setting its value.
+     * Sets a response header with the given name and value. If the header had already been set, the new value overwrites
+     * the previous one. The <code>containsHeader</code> method can be used to test for the presence of a header before
+     * setting its value.
      * 
-     * @param name  the name of the header
+     * @param name the name of the header
      * @param value the header value If it contains octet string, it should be encoded according to RFC 2047
-     *              (http://www.ietf.org/rfc/rfc2047.txt)
+     * (http://www.ietf.org/rfc/rfc2047.txt)
      *
      * @see #containsHeader
      * @see #addHeader
@@ -229,12 +226,11 @@ public interface HttpServletResponse extends ServletResponse {
     public void setHeader(String name, String value);
 
     /**
-     * Adds a response header with the given name and value. This method allows response headers to have multiple
-     * values.
+     * Adds a response header with the given name and value. This method allows response headers to have multiple values.
      * 
-     * @param name  the name of the header
+     * @param name the name of the header
      * @param value the additional header value If it contains octet string, it should be encoded according to RFC 2047
-     *              (http://www.ietf.org/rfc/rfc2047.txt)
+     * (http://www.ietf.org/rfc/rfc2047.txt)
      *
      * @see #setHeader
      */
@@ -242,10 +238,10 @@ public interface HttpServletResponse extends ServletResponse {
 
     /**
      * Sets a response header with the given name and integer value. If the header had already been set, the new value
-     * overwrites the previous one. The <code>containsHeader</code> method can be used to test for the presence of a
-     * header before setting its value.
+     * overwrites the previous one. The <code>containsHeader</code> method can be used to test for the presence of a header
+     * before setting its value.
      *
-     * @param name  the name of the header
+     * @param name the name of the header
      * @param value the assigned integer value
      *
      * @see #containsHeader
@@ -254,10 +250,10 @@ public interface HttpServletResponse extends ServletResponse {
     public void setIntHeader(String name, int value);
 
     /**
-     * Adds a response header with the given name and integer value. This method allows response headers to have
-     * multiple values.
+     * Adds a response header with the given name and integer value. This method allows response headers to have multiple
+     * values.
      *
-     * @param name  the name of the header
+     * @param name the name of the header
      * @param value the assigned integer value
      *
      * @see #setIntHeader
@@ -291,10 +287,9 @@ public interface HttpServletResponse extends ServletResponse {
 
     /**
      * @deprecated As of version 2.1, due to ambiguous meaning of the message parameter. To set a status code use
-     *             <code>setStatus(int)</code>, to send an error with a description use
-     *             <code>sendError(int, String)</code>.
+     * <code>setStatus(int)</code>, to send an error with a description use <code>sendError(int, String)</code>.
      *
-     *             Sets the status code and message for this response.
+     * Sets the status code and message for this response.
      * 
      * @param sc the status code
      * @param sm the status message
@@ -315,8 +310,8 @@ public interface HttpServletResponse extends ServletResponse {
      * Gets the value of the response header with the given name.
      * 
      * <p>
-     * If a response header with the given name exists and contains multiple values, the value that was added first will
-     * be returned.
+     * If a response header with the given name exists and contains multiple values, the value that was added first will be
+     * returned.
      *
      * <p>
      * This method considers only response headers set or added via {@link #setHeader}, {@link #addHeader},
@@ -324,8 +319,8 @@ public interface HttpServletResponse extends ServletResponse {
      *
      * @param name the name of the response header whose value to return
      *
-     * @return the value of the response header with the given name, or <tt>null</tt> if no header with the given name
-     *         has been set on this response
+     * @return the value of the response header with the given name, or <tt>null</tt> if no header with the given name has
+     * been set on this response
      *
      * @since Servlet 3.0
      */
@@ -383,18 +378,18 @@ public interface HttpServletResponse extends ServletResponse {
      * </p>
      *
      * <p>
-     * The RFC requires the name of every key that is to be in the supplied Map is included in the comma separated list
-     * that is the value of the "Trailer" response header. The application is responsible for ensuring this requirement
-     * is met. Failure to do so may lead to interoperability failures.
+     * The RFC requires the name of every key that is to be in the supplied Map is included in the comma separated list that
+     * is the value of the "Trailer" response header. The application is responsible for ensuring this requirement is met.
+     * Failure to do so may lead to interoperability failures.
      * </p>
      *
      * @implSpec The default implementation is a no-op.
      *
      * @param supplier the supplier of trailer headers
      *
-     * @exception IllegalStateException if it is invoked after the response has has been committed, or the trailer is
-     *                                  not supported in the request, for instance, the underlying protocol is HTTP 1.0,
-     *                                  or the response is not in chunked encoding in HTTP 1.1.
+     * @exception IllegalStateException if it is invoked after the response has has been committed, or the trailer is not
+     * supported in the request, for instance, the underlying protocol is HTTP 1.0, or the response is not in chunked
+     * encoding in HTTP 1.1.
      *
      * @since Servlet 4.0
      */
@@ -454,8 +449,8 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_NO_CONTENT = 204;
 
     /**
-     * Status code (205) indicating that the agent <em>SHOULD</em> reset the document view which caused the request to
-     * be sent.
+     * Status code (205) indicating that the agent <em>SHOULD</em> reset the document view which caused the request to be
+     * sent.
      */
     public static final int SC_RESET_CONTENT = 205;
 
@@ -471,23 +466,23 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_MULTIPLE_CHOICES = 300;
 
     /**
-     * Status code (301) indicating that the resource has permanently moved to a new location, and that future
-     * references should use a new URI with their requests.
+     * Status code (301) indicating that the resource has permanently moved to a new location, and that future references
+     * should use a new URI with their requests.
      */
     public static final int SC_MOVED_PERMANENTLY = 301;
 
     /**
-     * Status code (302) indicating that the resource has temporarily moved to another location, but that future
-     * references should still use the original URI to access the resource.
+     * Status code (302) indicating that the resource has temporarily moved to another location, but that future references
+     * should still use the original URI to access the resource.
      *
      * This definition is being retained for backwards compatibility. SC_FOUND is now the preferred definition.
      */
     public static final int SC_MOVED_TEMPORARILY = 302;
 
     /**
-     * Status code (302) indicating that the resource reside temporarily under a different URI. Since the redirection
-     * might be altered on occasion, the client should continue to use the Request-URI for future requests.(HTTP/1.1) To
-     * represent the status code (302), it is recommended to use this variable.
+     * Status code (302) indicating that the resource reside temporarily under a different URI. Since the redirection might
+     * be altered on occasion, the client should continue to use the Request-URI for future requests.(HTTP/1.1) To represent
+     * the status code (302), it is recommended to use this variable.
      */
     public static final int SC_FOUND = 302;
 
@@ -497,8 +492,7 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_SEE_OTHER = 303;
 
     /**
-     * Status code (304) indicating that a conditional GET operation found that the resource was available and not
-     * modified.
+     * Status code (304) indicating that a conditional GET operation found that the resource was available and not modified.
      */
     public static final int SC_NOT_MODIFIED = 304;
 
@@ -509,8 +503,8 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_USE_PROXY = 305;
 
     /**
-     * Status code (307) indicating that the requested resource resides temporarily under a different URI. The temporary
-     * URI <em>SHOULD</em> be given by the <code><em>Location</em></code> field in the response.
+     * Status code (307) indicating that the requested resource resides temporarily under a different URI. The temporary URI
+     * <em>SHOULD</em> be given by the <code><em>Location</em></code> field in the response.
      */
     public static final int SC_TEMPORARY_REDIRECT = 307;
 
@@ -540,8 +534,8 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_NOT_FOUND = 404;
 
     /**
-     * Status code (405) indicating that the method specified in the <code><em>Request-Line</em></code> is not allowed
-     * for the resource identified by the <code><em>Request-URI</em></code>.
+     * Status code (405) indicating that the method specified in the <code><em>Request-Line</em></code> is not allowed for
+     * the resource identified by the <code><em>Request-URI</em></code>.
      */
     public static final int SC_METHOD_NOT_ALLOWED = 405;
 
@@ -557,14 +551,14 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_PROXY_AUTHENTICATION_REQUIRED = 407;
 
     /**
-     * Status code (408) indicating that the client did not produce a request within the time that the server was
-     * prepared to wait.
+     * Status code (408) indicating that the client did not produce a request within the time that the server was prepared
+     * to wait.
      */
     public static final int SC_REQUEST_TIMEOUT = 408;
 
     /**
-     * Status code (409) indicating that the request could not be completed due to a conflict with the current state of
-     * the resource.
+     * Status code (409) indicating that the request could not be completed due to a conflict with the current state of the
+     * resource.
      */
     public static final int SC_CONFLICT = 409;
 
@@ -587,8 +581,8 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_PRECONDITION_FAILED = 412;
 
     /**
-     * Status code (413) indicating that the server is refusing to process the request because the request entity is
-     * larger than the server is willing or able to process.
+     * Status code (413) indicating that the server is refusing to process the request because the request entity is larger
+     * than the server is willing or able to process.
      */
     public static final int SC_REQUEST_ENTITY_TOO_LARGE = 413;
 
@@ -599,8 +593,8 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_REQUEST_URI_TOO_LONG = 414;
 
     /**
-     * Status code (415) indicating that the server is refusing to service the request because the entity of the request
-     * is in a format not supported by the requested resource for the requested method.
+     * Status code (415) indicating that the server is refusing to service the request because the entity of the request is
+     * in a format not supported by the requested resource for the requested method.
      */
     public static final int SC_UNSUPPORTED_MEDIA_TYPE = 415;
 
@@ -625,8 +619,8 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_NOT_IMPLEMENTED = 501;
 
     /**
-     * Status code (502) indicating that the HTTP server received an invalid response from a server it consulted when
-     * acting as a proxy or gateway.
+     * Status code (502) indicating that the HTTP server received an invalid response from a server it consulted when acting
+     * as a proxy or gateway.
      */
     public static final int SC_BAD_GATEWAY = 502;
 
@@ -636,14 +630,14 @@ public interface HttpServletResponse extends ServletResponse {
     public static final int SC_SERVICE_UNAVAILABLE = 503;
 
     /**
-     * Status code (504) indicating that the server did not receive a timely response from the upstream server while
-     * acting as a gateway or proxy.
+     * Status code (504) indicating that the server did not receive a timely response from the upstream server while acting
+     * as a gateway or proxy.
      */
     public static final int SC_GATEWAY_TIMEOUT = 504;
 
     /**
-     * Status code (505) indicating that the server does not support or refuses to support the HTTP protocol version
-     * that was used in the request message.
+     * Status code (505) indicating that the server does not support or refuses to support the HTTP protocol version that
+     * was used in the request message.
      */
     public static final int SC_HTTP_VERSION_NOT_SUPPORTED = 505;
 }

--- a/api/src/main/java/jakarta/servlet/http/HttpServletResponseWrapper.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletResponseWrapper.java
@@ -18,11 +18,11 @@
 
 package jakarta.servlet.http;
 
+import jakarta.servlet.ServletResponseWrapper;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.function.Supplier;
-import jakarta.servlet.ServletResponseWrapper;
 
 /**
  * 
@@ -131,8 +131,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behavior of this method is to call setDateHeader(String name, long date) on the wrapped response
-     * object.
+     * The default behavior of this method is to call setDateHeader(String name, long date) on the wrapped response object.
      */
     @Override
     public void setDateHeader(String name, long date) {
@@ -140,8 +139,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behavior of this method is to call addDateHeader(String name, long date) on the wrapped response
-     * object.
+     * The default behavior of this method is to call addDateHeader(String name, long date) on the wrapped response object.
      */
     @Override
     public void addDateHeader(String name, long date) {
@@ -149,8 +147,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behavior of this method is to return setHeader(String name, String value) on the wrapped response
-     * object.
+     * The default behavior of this method is to return setHeader(String name, String value) on the wrapped response object.
      */
     @Override
     public void setHeader(String name, String value) {
@@ -158,8 +155,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behavior of this method is to return addHeader(String name, String value) on the wrapped response
-     * object.
+     * The default behavior of this method is to return addHeader(String name, String value) on the wrapped response object.
      */
     @Override
     public void addHeader(String name, String value) {
@@ -167,8 +163,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behavior of this method is to call setIntHeader(String name, int value) on the wrapped response
-     * object.
+     * The default behavior of this method is to call setIntHeader(String name, int value) on the wrapped response object.
      */
     @Override
     public void setIntHeader(String name, int value) {
@@ -176,8 +171,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behavior of this method is to call addIntHeader(String name, int value) on the wrapped response
-     * object.
+     * The default behavior of this method is to call addIntHeader(String name, int value) on the wrapped response object.
      */
     @Override
     public void addIntHeader(String name, int value) {
@@ -196,7 +190,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
      * The default behavior of this method is to call setStatus(int sc, String sm) on the wrapped response object.
      *
      * @deprecated As of version 2.1, due to ambiguous meaning of the message parameter. To set a status code use
-     *             {@link #setStatus(int)}, to send an error with a description use {@link #sendError(int, String)}
+     * {@link #setStatus(int)}, to send an error with a description use {@link #sendError(int, String)}
      */
     @Deprecated
     @Override
@@ -205,8 +199,7 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behaviour of this method is to call {@link HttpServletResponse#getStatus} on the wrapped response
-     * object.
+     * The default behaviour of this method is to call {@link HttpServletResponse#getStatus} on the wrapped response object.
      *
      * @return the current status code of the wrapped response
      */
@@ -216,13 +209,12 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behaviour of this method is to call {@link HttpServletResponse#getHeader} on the wrapped response
-     * object.
+     * The default behaviour of this method is to call {@link HttpServletResponse#getHeader} on the wrapped response object.
      *
      * @param name the name of the response header whose value to return
      *
-     * @return the value of the response header with the given name, or <tt>null</tt> if no header with the given name
-     *         has been set on the wrapped response
+     * @return the value of the response header with the given name, or <tt>null</tt> if no header with the given name has
+     * been set on the wrapped response
      *
      * @since Servlet 3.0
      */
@@ -250,8 +242,8 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behaviour of this method is to call {@link HttpServletResponse#getHeaderNames} on the wrapped
-     * response object.
+     * The default behaviour of this method is to call {@link HttpServletResponse#getHeaderNames} on the wrapped response
+     * object.
      *
      * <p>
      * Any changes to the returned <code>Collection</code> must not affect this <code>HttpServletResponseWrapper</code>.
@@ -266,8 +258,8 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behaviour of this method is to call {@link HttpServletResponse#setTrailerFields} on the wrapped
-     * response object.
+     * The default behaviour of this method is to call {@link HttpServletResponse#setTrailerFields} on the wrapped response
+     * object.
      *
      * @param supplier of trailer headers
      *
@@ -279,8 +271,8 @@ public class HttpServletResponseWrapper extends ServletResponseWrapper implement
     }
 
     /**
-     * The default behaviour of this method is to call {@link HttpServletResponse#getTrailerFields} on the wrapped
-     * response object.
+     * The default behaviour of this method is to call {@link HttpServletResponse#getTrailerFields} on the wrapped response
+     * object.
      *
      * @return supplier of trailer headers
      *

--- a/api/src/main/java/jakarta/servlet/http/HttpSession.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSession.java
@@ -18,8 +18,8 @@
 
 package jakarta.servlet.http;
 
-import java.util.Enumeration;
 import jakarta.servlet.ServletContext;
+import java.util.Enumeration;
 
 /**
  *
@@ -71,16 +71,15 @@ public interface HttpSession {
      *
      * Returns the time when this session was created, measured in milliseconds since midnight January 1, 1970 GMT.
      *
-     * @return a <code>long</code> specifying when this session was created, expressed in milliseconds since 1/1/1970
-     *         GMT
+     * @return a <code>long</code> specifying when this session was created, expressed in milliseconds since 1/1/1970 GMT
      *
      * @exception IllegalStateException if this method is called on an invalidated session
      */
     public long getCreationTime();
 
     /**
-     * Returns a string containing the unique identifier assigned to this session. The identifier is assigned by the
-     * servlet container and is implementation dependent.
+     * Returns a string containing the unique identifier assigned to this session. The identifier is assigned by the servlet
+     * container and is implementation dependent.
      * 
      * @return a string specifying the identifier assigned to this session
      */
@@ -92,11 +91,11 @@ public interface HttpSession {
      * midnight January 1, 1970 GMT, and marked by the time the container received the request.
      *
      * <p>
-     * Actions that your application takes, such as getting or setting a value associated with the session, do not
-     * affect the access time.
+     * Actions that your application takes, such as getting or setting a value associated with the session, do not affect
+     * the access time.
      *
      * @return a <code>long</code> representing the last time the client sent a request associated with this session,
-     *         expressed in milliseconds since 1/1/1970 GMT
+     * expressed in milliseconds since 1/1/1970 GMT
      *
      * @exception IllegalStateException if this method is called on an invalidated session
      */
@@ -111,8 +110,7 @@ public interface HttpSession {
     public ServletContext getServletContext();
 
     /**
-     * Specifies the time, in seconds, between client requests before the servlet container will invalidate this
-     * session.
+     * Specifies the time, in seconds, between client requests before the servlet container will invalidate this session.
      *
      * <p>
      * An <tt>interval</tt> value of zero or less indicates that the session should never timeout.
@@ -122,9 +120,9 @@ public interface HttpSession {
     public void setMaxInactiveInterval(int interval);
 
     /**
-     * Returns the maximum time interval, in seconds, that the servlet container will keep this session open between
-     * client accesses. After this interval, the servlet container will invalidate the session. The maximum time
-     * interval can be set with the <code>setMaxInactiveInterval</code> method.
+     * Returns the maximum time interval, in seconds, that the servlet container will keep this session open between client
+     * accesses. After this interval, the servlet container will invalidate the session. The maximum time interval can be
+     * set with the <code>setMaxInactiveInterval</code> method.
      *
      * <p>
      * A return value of zero or less indicates that the session will never timeout.
@@ -138,7 +136,7 @@ public interface HttpSession {
     /**
      *
      * @deprecated As of Version 2.1, this method is deprecated and has no replacement. It will be removed in a future
-     *             version of Jakarta Servlets.
+     * version of Jakarta Servlets.
      *
      * @return the {@link HttpSessionContext} for this session.
      */
@@ -146,8 +144,8 @@ public interface HttpSession {
     public HttpSessionContext getSessionContext();
 
     /**
-     * Returns the object bound with the specified name in this session, or <code>null</code> if no object is bound
-     * under the name.
+     * Returns the object bound with the specified name in this session, or <code>null</code> if no object is bound under
+     * the name.
      *
      * @param name a string specifying the name of the object
      *
@@ -170,11 +168,11 @@ public interface HttpSession {
     public Object getValue(String name);
 
     /**
-     * Returns an <code>Enumeration</code> of <code>String</code> objects containing the names of all the objects bound
-     * to this session.
+     * Returns an <code>Enumeration</code> of <code>String</code> objects containing the names of all the objects bound to
+     * this session.
      *
-     * @return an <code>Enumeration</code> of <code>String</code> objects specifying the names of all the objects bound
-     *         to this session
+     * @return an <code>Enumeration</code> of <code>String</code> objects specifying the names of all the objects bound to
+     * this session
      *
      * @exception IllegalStateException if this method is called on an invalidated session
      */
@@ -195,20 +193,19 @@ public interface HttpSession {
      * session, the object is replaced.
      *
      * <p>
-     * After this method executes, and if the new object implements <code>HttpSessionBindingListener</code>, the
-     * container calls <code>HttpSessionBindingListener.valueBound</code>. The container then notifies any
+     * After this method executes, and if the new object implements <code>HttpSessionBindingListener</code>, the container
+     * calls <code>HttpSessionBindingListener.valueBound</code>. The container then notifies any
      * <code>HttpSessionAttributeListener</code>s in the web application.
      * 
      * <p>
-     * If an object was already bound to this session of this name that implements
-     * <code>HttpSessionBindingListener</code>, its <code>HttpSessionBindingListener.valueUnbound</code> method is
-     * called.
+     * If an object was already bound to this session of this name that implements <code>HttpSessionBindingListener</code>,
+     * its <code>HttpSessionBindingListener.valueUnbound</code> method is called.
      *
      * <p>
      * If the value passed in is null, this has the same effect as calling <code>removeAttribute()</code>.
      *
      *
-     * @param name  the name to which the object is bound; cannot be null
+     * @param name the name to which the object is bound; cannot be null
      *
      * @param value the object to be bound
      *
@@ -219,7 +216,7 @@ public interface HttpSession {
     /**
      * @deprecated As of Version 2.2, this method is replaced by {@link #setAttribute}
      *
-     * @param name  the name to which the object is bound; cannot be null
+     * @param name the name to which the object is bound; cannot be null
      *
      * @param value the object to be bound; cannot be null
      *
@@ -229,12 +226,12 @@ public interface HttpSession {
     public void putValue(String name, Object value);
 
     /**
-     * Removes the object bound with the specified name from this session. If the session does not have an object bound
-     * with the specified name, this method does nothing.
+     * Removes the object bound with the specified name from this session. If the session does not have an object bound with
+     * the specified name, this method does nothing.
      *
      * <p>
-     * After this method executes, and if the object implements <code>HttpSessionBindingListener</code>, the container
-     * calls <code>HttpSessionBindingListener.valueUnbound</code>. The container then notifies any
+     * After this method executes, and if the object implements <code>HttpSessionBindingListener</code>, the container calls
+     * <code>HttpSessionBindingListener.valueUnbound</code>. The container then notifies any
      * <code>HttpSessionAttributeListener</code>s in the web application.
      *
      * @param name the name of the object to remove from this session
@@ -261,9 +258,9 @@ public interface HttpSession {
     public void invalidate();
 
     /**
-     * Returns <code>true</code> if the client does not yet know about the session or if the client chooses not to join
-     * the session. For example, if the server used only cookie-based sessions, and the client had disabled the use of
-     * cookies, then a session would be new on each request.
+     * Returns <code>true</code> if the client does not yet know about the session or if the client chooses not to join the
+     * session. For example, if the server used only cookie-based sessions, and the client had disabled the use of cookies,
+     * then a session would be new on each request.
      *
      * @return <code>true</code> if the server has created a session, but the client has not yet joined
      *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionAttributeListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionAttributeListener.java
@@ -25,8 +25,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link jakarta.servlet.ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link jakarta.servlet.ServletContext}.
  *
  * <p>
  * The order in which implementations of this interface are invoked is unspecified.
@@ -39,7 +39,7 @@ public interface HttpSessionAttributeListener extends EventListener {
      * Receives notification that an attribute has been added to a session.
      *
      * @param event the HttpSessionBindingEvent containing the session and the name and value of the attribute that was
-     *              added
+     * added
      */
     default public void attributeAdded(HttpSessionBindingEvent event) {
     }
@@ -48,7 +48,7 @@ public interface HttpSessionAttributeListener extends EventListener {
      * Receives notification that an attribute has been removed from a session.
      *
      * @param event the HttpSessionBindingEvent containing the session and the name and value of the attribute that was
-     *              removed
+     * removed
      */
     default public void attributeRemoved(HttpSessionBindingEvent event) {
     }
@@ -56,8 +56,8 @@ public interface HttpSessionAttributeListener extends EventListener {
     /**
      * Receives notification that an attribute has been replaced in a session.
      *
-     * @param event the HttpSessionBindingEvent containing the session and the name and (old) value of the attribute
-     *              that was replaced
+     * @param event the HttpSessionBindingEvent containing the session and the name and (old) value of the attribute that
+     * was replaced
      */
     default public void attributeReplaced(HttpSessionBindingEvent event) {
     }

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionBindingEvent.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionBindingEvent.java
@@ -50,7 +50,7 @@ public class HttpSessionBindingEvent extends HttpSessionEvent {
      * event, the object must implement {@link HttpSessionBindingListener}.
      *
      * @param session the session to which the object is bound or unbound
-     * @param name    the name with which the object is bound or unbound
+     * @param name the name with which the object is bound or unbound
      *
      * @see #getName
      * @see #getSession
@@ -66,8 +66,8 @@ public class HttpSessionBindingEvent extends HttpSessionEvent {
      * event, the object must implement {@link HttpSessionBindingListener}.
      *
      * @param session the session to which the object is bound or unbound
-     * @param name    the name with which the object is bound or unbound
-     * @param value   the object that is bound or unbound
+     * @param name the name with which the object is bound or unbound
+     * @param value the object that is bound or unbound
      *
      * @see #getName
      * @see #getSession
@@ -88,9 +88,9 @@ public class HttpSessionBindingEvent extends HttpSessionEvent {
     }
 
     /**
-     * Returns the value of the attribute that has been added, removed or replaced. If the attribute was added (or
-     * bound), this is the value of the attribute. If the attribute was removed (or unbound), this is the value of the
-     * removed attribute. If the attribute was replaced, this is the old value of the attribute.
+     * Returns the value of the attribute that has been added, removed or replaced. If the attribute was added (or bound),
+     * this is the value of the attribute. If the attribute was removed (or unbound), this is the value of the removed
+     * attribute. If the attribute was replaced, this is the old value of the attribute.
      *
      * @return the value of the attribute that has been added, removed or replaced
      *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionContext.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionContext.java
@@ -25,7 +25,7 @@ import java.util.Enumeration;
  * @author Various
  *
  * @deprecated As of Java(tm) Servlet API 2.1 for security reasons, with no replacement. This interface will be removed
- *             in a future version of this API.
+ * in a future version of this API.
  *
  * @see HttpSession
  * @see HttpSessionBindingEvent
@@ -38,7 +38,7 @@ public interface HttpSessionContext {
     /**
      *
      * @deprecated As of Java Servlet API 2.1 with no replacement. This method must return null and will be removed in a
-     *             future version of this API.
+     * future version of this API.
      * @param sessionId the id of the session to be returned
      *
      * @return null in all cases
@@ -48,8 +48,8 @@ public interface HttpSessionContext {
 
     /**
      *
-     * @deprecated As of Java Servlet API 2.1 with no replacement. This method must return an empty
-     *             <code>Enumeration</code> and will be removed in a future version of this API.
+     * @deprecated As of Java Servlet API 2.1 with no replacement. This method must return an empty <code>Enumeration</code>
+     * and will be removed in a future version of this API.
      *
      * @return null
      *

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionIdListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionIdListener.java
@@ -24,8 +24,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link jakarta.servlet.ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link jakarta.servlet.ServletContext}.
  *
  * <p>
  * The order in which implementations of this interface are invoked is unspecified.
@@ -37,8 +37,8 @@ public interface HttpSessionIdListener extends EventListener {
     /**
      * Receives notification that session id has been changed in a session.
      *
-     * @param event        the HttpSessionBindingEvent containing the session and the name and (old) value of the
-     *                     attribute that was replaced
+     * @param event the HttpSessionBindingEvent containing the session and the name and (old) value of the attribute that
+     * was replaced
      *
      * @param oldSessionId the old session id
      */

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionListener.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionListener.java
@@ -25,8 +25,8 @@ import java.util.EventListener;
  *
  * <p>
  * In order to receive these notification events, the implementation class must be either declared in the deployment
- * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via one
- * of the addListener methods defined on {@link jakarta.servlet.ServletContext}.
+ * descriptor of the web application, annotated with {@link jakarta.servlet.annotation.WebListener}, or registered via
+ * one of the addListener methods defined on {@link jakarta.servlet.ServletContext}.
  *
  * <p>
  * Implementations of this interface are invoked at their {@link #sessionCreated} method in the order in which they have

--- a/api/src/main/java/jakarta/servlet/http/HttpUpgradeHandler.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpUpgradeHandler.java
@@ -25,8 +25,8 @@ package jakarta.servlet.http;
  */
 public interface HttpUpgradeHandler {
     /**
-     * It is called once the HTTP Upgrade process has been completed and the upgraded connection is ready to start using
-     * the new protocol.
+     * It is called once the HTTP Upgrade process has been completed and the upgraded connection is ready to start using the
+     * new protocol.
      *
      * @param wc the WebConnection object associated to this upgrade request
      */

--- a/api/src/main/java/jakarta/servlet/http/HttpUtils.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpUtils.java
@@ -19,14 +19,14 @@
 package jakarta.servlet.http;
 
 import jakarta.servlet.ServletInputStream;
+import java.io.IOException;
 import java.util.Hashtable;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
-import java.io.IOException;
 
 /**
  * @deprecated As of Java(tm) Servlet API 2.3. These methods were only useful with the default encoding and have been
- *             moved to the request interfaces.
+ * moved to the request interfaces.
  *
  */
 @Deprecated
@@ -42,18 +42,17 @@ public class HttpUtils {
     }
 
     /**
-     * Parses a query string passed from the client to the server and builds a <code>HashTable</code> object with
-     * key-value pairs. The query string should be in the form of a string packaged by the GET or POST method, that is,
-     * it should have key-value pairs in the form <i>key=value</i>, with each pair separated from the next by a &amp;
-     * character.
+     * Parses a query string passed from the client to the server and builds a <code>HashTable</code> object with key-value
+     * pairs. The query string should be in the form of a string packaged by the GET or POST method, that is, it should have
+     * key-value pairs in the form <i>key=value</i>, with each pair separated from the next by a &amp; character.
      *
      * <p>
-     * A key can appear more than once in the query string with different values. However, the key appears only once in
-     * the hashtable, with its value being an array of strings containing the multiple values sent by the query string.
+     * A key can appear more than once in the query string with different values. However, the key appears only once in the
+     * hashtable, with its value being an array of strings containing the multiple values sent by the query string.
      * 
      * <p>
-     * The keys and values in the hashtable are stored in their decoded form, so any + characters are converted to
-     * spaces, and characters sent in hexadecimal notation (like <i>%xx</i>) are converted to ASCII characters.
+     * The keys and values in the hashtable are stored in their decoded form, so any + characters are converted to spaces,
+     * and characters sent in hexadecimal notation (like <i>%xx</i>) are converted to ASCII characters.
      *
      * @param s a string containing the query to be parsed
      *
@@ -110,13 +109,13 @@ public class HttpUtils {
      * containing the multiple values sent by the POST method.
      *
      * <p>
-     * The keys and values in the hashtable are stored in their decoded form, so any + characters are converted to
-     * spaces, and characters sent in hexadecimal notation (like <i>%xx</i>) are converted to ASCII characters.
+     * The keys and values in the hashtable are stored in their decoded form, so any + characters are converted to spaces,
+     * and characters sent in hexadecimal notation (like <i>%xx</i>) are converted to ASCII characters.
      *
      * @param len an integer specifying the length, in characters, of the <code>ServletInputStream</code> object that is
-     *            also passed to this method
+     * also passed to this method
      *
-     * @param in  the <code>ServletInputStream</code> object that contains the data sent from the client
+     * @param in the <code>ServletInputStream</code> object that contains the data sent from the client
      * 
      * @return a <code>HashTable</code> object built from the parsed key-value pairs
      *
@@ -208,13 +207,13 @@ public class HttpUtils {
 
     /**
      *
-     * Reconstructs the URL the client used to make the request, using information in the
-     * <code>HttpServletRequest</code> object. The returned URL contains a protocol, server name, port number, and
-     * server path, but it does not include query string parameters.
+     * Reconstructs the URL the client used to make the request, using information in the <code>HttpServletRequest</code>
+     * object. The returned URL contains a protocol, server name, port number, and server path, but it does not include
+     * query string parameters.
      * 
      * <p>
-     * Because this method returns a <code>StringBuffer</code>, not a string, you can modify the URL easily, for
-     * example, to append query parameters.
+     * Because this method returns a <code>StringBuffer</code>, not a string, you can modify the URL easily, for example, to
+     * append query parameters.
      *
      * <p>
      * This method is useful for creating redirect messages and for reporting errors.

--- a/api/src/main/java/jakarta/servlet/http/Part.java
+++ b/api/src/main/java/jakarta/servlet/http/Part.java
@@ -71,14 +71,13 @@ public interface Part {
      * 
      * <p>
      * This method is not guaranteed to succeed if called more than once for the same part. This allows a particular
-     * implementation to use, for example, file renaming, where possible, rather than copying all of the underlying
-     * data, thus gaining a significant performance benefit.
+     * implementation to use, for example, file renaming, where possible, rather than copying all of the underlying data,
+     * thus gaining a significant performance benefit.
      *
-     * @param fileName The location into which the uploaded part should be stored. Relative paths are relative to 
-     *                 {@link jakarta.servlet.MultipartConfigElement#getLocation()}. Absolute paths are used as 
-     *                 provided. Note: that this is a system dependent string and URI notation may not be 
-     *                 acceptable on all systems. For portability, this string should be generated with the
-     *                 File or Path APIs.
+     * @param fileName The location into which the uploaded part should be stored. Relative paths are relative to
+     * {@link jakarta.servlet.MultipartConfigElement#getLocation()}. Absolute paths are used as provided. Note: that this is
+     * a system dependent string and URI notation may not be acceptable on all systems. For portability, this string should
+     * be generated with the File or Path APIs.
      *
      * @throws IOException if an error occurs.
      */
@@ -93,15 +92,15 @@ public interface Part {
 
     /**
      *
-     * Returns the value of the specified mime header as a <code>String</code>. If the Part did not include a header of
-     * the specified name, this method returns <code>null</code>. If there are multiple headers with the same name, this
-     * method returns the first header in the part. The header name is case insensitive. You can use this method with
-     * any request header.
+     * Returns the value of the specified mime header as a <code>String</code>. If the Part did not include a header of the
+     * specified name, this method returns <code>null</code>. If there are multiple headers with the same name, this method
+     * returns the first header in the part. The header name is case insensitive. You can use this method with any request
+     * header.
      *
      * @param name a <code>String</code> specifying the header name
      *
-     * @return a <code>String</code> containing the value of the requested header, or <code>null</code> if the part does
-     *         not have a header of that name
+     * @return a <code>String</code> containing the value of the requested header, or <code>null</code> if the part does not
+     * have a header of that name
      */
     public String getHeader(String name);
 
@@ -124,8 +123,8 @@ public interface Part {
      * Gets the header names of this Part.
      *
      * <p>
-     * Some servlet containers do not allow servlets to access headers using this method, in which case this method
-     * returns <code>null</code>
+     * Some servlet containers do not allow servlets to access headers using this method, in which case this method returns
+     * <code>null</code>
      *
      * <p>
      * Any changes to the returned <code>Collection</code> must not affect this <code>Part</code>.

--- a/api/src/main/java/jakarta/servlet/http/PushBuilder.java
+++ b/api/src/main/java/jakarta/servlet/http/PushBuilder.java
@@ -92,10 +92,10 @@ public interface PushBuilder {
      * 
      * @param method the method to be used for the push.
      *
-     * @throws NullPointerException     if the argument is {@code null}
+     * @throws NullPointerException if the argument is {@code null}
      *
-     * @throws IllegalArgumentException if the argument is the empty String, or any non-cacheable or unsafe methods
-     *                                  defined in RFC 7231, which are POST, PUT, DELETE, CONNECT, OPTIONS and TRACE.
+     * @throws IllegalArgumentException if the argument is the empty String, or any non-cacheable or unsafe methods defined
+     * in RFC 7231, which are POST, PUT, DELETE, CONNECT, OPTIONS and TRACE.
      *
      * @return this builder.
      */
@@ -105,8 +105,8 @@ public interface PushBuilder {
      * Set the query string to be used for the push.
      *
      * The query string will be appended to any query String included in a call to {@link #path(String)}. Any duplicate
-     * parameters must be preserved. This method should be used instead of a query in {@link #path(String)} when
-     * multiple {@link #push()} calls are to be made with the same query string.
+     * parameters must be preserved. This method should be used instead of a query in {@link #path(String)} when multiple
+     * {@link #push()} calls are to be made with the same query string.
      * 
      * @param queryString the query string to be used for the push.
      * @return this builder.
@@ -115,9 +115,8 @@ public interface PushBuilder {
 
     /**
      * Set the SessionID to be used for the push. The session ID will be set in the same way it was on the associated
-     * request (ie as a cookie if the associated request used a cookie, or as a url parameter if the associated request
-     * used a url parameter). Defaults to the requested session ID or any newly assigned session id from a newly created
-     * session.
+     * request (ie as a cookie if the associated request used a cookie, or as a url parameter if the associated request used
+     * a url parameter). Defaults to the requested session ID or any newly assigned session id from a newly created session.
      * 
      * @param sessionId the SessionID to be used for the push.
      * @return this builder.
@@ -126,11 +125,11 @@ public interface PushBuilder {
 
     /**
      * <p>
-     * Set a request header to be used for the push. If the builder has an existing header with the same name, its value
-     * is overwritten.
+     * Set a request header to be used for the push. If the builder has an existing header with the same name, its value is
+     * overwritten.
      * </p>
      *
-     * @param name  The header name to set
+     * @param name The header name to set
      * @param value The header value to set
      * @return this builder.
      */
@@ -141,7 +140,7 @@ public interface PushBuilder {
      * Add a request header to be used for the push.
      * </p>
      * 
-     * @param name  The header name to add
+     * @param name The header name to add
      * @param value The header value to add
      * @return this builder.
      */
@@ -173,24 +172,23 @@ public interface PushBuilder {
      * Push a resource given the current state of the builder, the method must be non-blocking.
      *
      * <p>
-     * Push a resource based on the current state of the PushBuilder. Calling this method does not guarantee the
-     * resource will actually be pushed, since it is possible the client can decline acceptance of the pushed resource
-     * using the underlying HTTP/2 protocol.
+     * Push a resource based on the current state of the PushBuilder. Calling this method does not guarantee the resource
+     * will actually be pushed, since it is possible the client can decline acceptance of the pushed resource using the
+     * underlying HTTP/2 protocol.
      * </p>
      *
      * <p>
-     * If the builder has a session ID, then the pushed request will include the session ID either as a Cookie or as a
-     * URI parameter as appropriate. The builders query string is merged with any passed query string.
+     * If the builder has a session ID, then the pushed request will include the session ID either as a Cookie or as a URI
+     * parameter as appropriate. The builders query string is merged with any passed query string.
      * </p>
      *
      * <p>
-     * Before returning from this method, the builder has its path, conditional headers (defined in RFC 7232) nulled.
-     * All other fields are left as is for possible reuse in another push.
+     * Before returning from this method, the builder has its path, conditional headers (defined in RFC 7232) nulled. All
+     * other fields are left as is for possible reuse in another push.
      * </p>
      *
-     * @throws IllegalStateException if there was no call to {@link #path} on this instance either between its
-     *                               instantiation or the last call to {@code push()} that did not throw an
-     *                               IllegalStateException.
+     * @throws IllegalStateException if there was no call to {@link #path} on this instance either between its instantiation
+     * or the last call to {@code push()} that did not throw an IllegalStateException.
      */
     public void push();
 
@@ -219,8 +217,8 @@ public interface PushBuilder {
      * Return the set of header to be used for the push.
      *
      * <p>
-     * The returned set is not backed by the {@code PushBuilder} object, so changes in the returned set are not
-     * reflected in the {@code PushBuilder} object, and vice-versa.
+     * The returned set is not backed by the {@code PushBuilder} object, so changes in the returned set are not reflected in
+     * the {@code PushBuilder} object, and vice-versa.
      * </p>
      *
      * @return the set of header to be used for the push.

--- a/api/src/main/java/jakarta/servlet/http/WebConnection.java
+++ b/api/src/main/java/jakarta/servlet/http/WebConnection.java
@@ -17,9 +17,9 @@
 
 package jakarta.servlet.http;
 
-import java.io.IOException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.ServletOutputStream;
+import java.io.IOException;
 
 /**
  * This interface encapsulates the connection for an upgrade request. It allows the protocol handler to send service

--- a/api/src/main/java/jakarta/servlet/http/package.html
+++ b/api/src/main/java/jakarta/servlet/http/package.html
@@ -16,21 +16,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
--->
-
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<HTML>
-<HEAD>
-
-
-</HEAD>
-<BODY BGCOLOR="white">
-
-The jakarta.servlet.http package contains a number of classes and interfaces
-that describe and define the contracts between a servlet class
-running under the HTTP protocol and the runtime environment provided
-for an instance of such a class by a conforming servlet container.
-
-
-</BODY>
-</HTML>
+--><!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+    <head> 
+    </head> 
+    <body bgcolor="white">
+         The jakarta.servlet.http package contains a number of classes and interfaces that describe and define the contracts between a servlet class running under the HTTP protocol and the runtime environment provided for an instance of such a class by a conforming servlet container.  
+    </body>
+</html>

--- a/api/src/main/java/jakarta/servlet/package.html
+++ b/api/src/main/java/jakarta/servlet/package.html
@@ -16,25 +16,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
--->
-
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<HTML>
-<HEAD>
-
-
-</HEAD>
-<BODY BGCOLOR="white">
-
-<p>
-The jakarta.servlet package contains a number of classes and interfaces that
-describe and define the contracts between a servlet class and the
-runtime environment provided for an instance of such a class by a
-conforming servlet container.
-For versions prior to 4.0.2 these classes and interfaces are described by
-the Java Servlet API Specification. For version 4.0.2 and later they are 
-described by the Jakarta Servlet Specification.
-</p>
-
-</BODY>
-</HTML>
+--><!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
+<html>
+    <head> 
+    </head> 
+    <body bgcolor="white"> 
+        <p> The jakarta.servlet package contains a number of classes and interfaces that describe and define the contracts between a servlet class and the runtime environment provided for an instance of such a class by a conforming servlet container. For versions prior to 4.0.2 these classes and interfaces are described by the Java Servlet API Specification. For version 4.0.2 and later they are described by the Jakarta Servlet Specification. </p>  
+    </body>
+</html>


### PR DESCRIPTION
Here is a different approach to format checking, as a possible alternative to https://github.com/eclipse-ee4j/servlet-api/pull/297

The resulting formatting is exactly the same (i.e. what you get when you run the eclipse formatter with the EE4J style), however the method it is applied is a bit different.

When you just run a normal build the formatter plugin will automatically fix the formatting for you, which means that contributors don't have to worry about setting up their IDE correctly to get the correct format, as any problems are automatically fixed. When running on CI it switches to validate mode, and ensures that running the formatter results in no changes to the files.

Another notable difference is that the code style has been copied into the repo, using a URL means that a change to the official style file could break our build.

I am happy to go with whatever the consensus is, but my personal experience with this approach has been very positive, and means you hardly ever end up with formatting errors on CI. 