### PR TITLE
Async Dispatch HttpServletMapping

### DIFF
--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -166,26 +166,47 @@ public interface HttpServletRequest extends ServletRequest {
     public int getIntHeader(String name);
 
     /**
+     * Return the HttpServletMapping for the current dispatch of the request.
      * <p>
-     * Return the {@link HttpServletMapping} by which the {@link HttpServlet} for this {@code HttpServletRequest} was
-     * invoked. The mappings for any applicable {@link jakarta.servlet.Filter}s are not indicated in the result.
-     * If the currently active {@link jakarta.servlet.Servlet} invocation was obtained by a call to
-     * {@link ServletRequest#getRequestDispatcher} followed by a call to {@link RequestDispatcher#forward}, the returned
-     * {@code HttpServletMapping} is the one corresponding to the path used to obtain the {@link RequestDispatcher}.
-     * If the currently active {@code Servlet} invocation was obtained by a call to
-     * {@link ServletRequest#getRequestDispatcher} followed by a call to {@link RequestDispatcher#include}, the returned
-     * {@code HttpServletMapping} is the one corresponding to the first {@code Servlet} in the invocation sequence that
-     * was invoked.
-     * If the currently active {@code Servlet} invocation was obtained by a call to
-     * {@link jakarta.servlet.AsyncContext#dispatch} or {@link jakarta.servlet.AsyncContext#dispatch(String)},
-     * the returned {@code HttpServletMapping} is the one corresponding to the first {@code Servlet} that will be invoked.
-     * See {@link jakarta.servlet.RequestDispatcher#FORWARD_MAPPING},
-     * {@link jakarta.servlet.RequestDispatcher#INCLUDE_MAPPING} and {@link jakarta.servlet.AsyncContext#ASYNC_MAPPING} for
-     * additional request attributes related to {@code HttpServletMapping}. If the currently active {@code Servlet}
-     * invocation was obtained by a call to {@link jakarta.servlet.ServletContext#getNamedDispatcher}, the returned
-     * {@code HttpServletMapping} is the one corresponding to the path for the mapping last applied to this request.
+     * The mapping returned depends on the current {@link jakarta.servlet.DispatcherType} as obtained from
+     * {@link #getDispatcherType()}:
+     *  <dl>
+     *   <dt>{@link jakarta.servlet.DispatcherType#REQUEST}</dt>
+     *   <dd>Return the mapping for the current {@code Servlet}.</dd>
+     *
+     *   <dt>{@link jakarta.servlet.DispatcherType#FORWARD}</dt>
+     *   <dd>If the {@link jakarta.servlet.RequestDispatcher} called was obtained
+     *       by {@link jakarta.servlet.ServletContext#getNamedDispatcher(String)} then
+     *       return the value that would have been returned prior to the call to 
+     *       {@link RequestDispatcher#forward(ServletRequest, ServletResponse)} 
+     *       i.e the value returned is unchanged by the forward call to a named dispatcher.
+     *       Otherwise return the mapping for the target of the dispatch 
+     *       i.e. the mapping for the current {@code Servlet}.</dd>
+     *
+     *   <dt>{@link jakarta.servlet.DispatcherType#INCLUDE}</dt>
+     *   <dd>Return the value that would have been returned prior to the call to 
+     *       {@link RequestDispatcher#include(ServletRequest, ServletResponse)}
+     *       i.e the value returned is unchanged by the include call.</dd>
+     *
+     *   <dt>{@link jakarta.servlet.DispatcherType#ASYNC}</dt>
+     *   <dd>Return the mapping for the target of the dispatch i.e. the mapping for the current
+     *       {@code Servlet}.</dd>
+     *
+     *   <dt>{@link jakarta.servlet.DispatcherType#ERROR}</dt>
+     *   <dd>Return the mapping for the target of the dispatch i.e. the mapping for the current
+     *       {@code Servlet}.</dd>
+     *  </dl>
      * </p>
-     * 
+     * <p>
+     * Note: For dispatch types that return the mapping for the source of the dispatch, the lookup of the
+     * mapping for the dispatch source is recursive. For example:
+     *  <ul>
+     *   <li>For a sequence Servlet1-&gt;include-&gt;Servlet2-&gt;include-&gt;Servlet3, a call to this method in
+     *       Servlet3 will return the mapping for Servlet1.</li>
+     *   <li>For a sequence Servlet1-&gt;async-&gt;Servlet2-&gt;include-&gt;Servlet3, a call to this method in
+     *       Servlet3 will return the mapping for Servlet2.</li>
+     *  </ul>
+     * </p>
      * <p>
      * The returned object is immutable. Servlet 4.0 compliant implementations must override this method.
      * </p>

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -168,18 +168,18 @@ public interface HttpServletRequest extends ServletRequest {
     /**
      * <p>
      * Return the {@link HttpServletMapping} by which the {@link HttpServlet} for this {@code HttpServletRequest} was
-     * invoked. The mappings for any applicable {@link jakarta.servlet.Filter}s are not indicated in the result. If the
-     * currently active {@link jakarta.servlet.Servlet} invocation was obtained by a call to
+     * invoked. The mappings for any applicable {@link jakarta.servlet.Filter}s are not indicated in the result.
+     * If the currently active {@link jakarta.servlet.Servlet} invocation was obtained by a call to
      * {@link ServletRequest#getRequestDispatcher} followed by a call to {@link RequestDispatcher#forward}, the returned
-     * {@code
-     * HttpServletMapping} is the one corresponding to the path used to obtain the {@link RequestDispatcher}. If the
-     * currently active {@code Servlet} invocation was obtained by a call to {@link ServletRequest#getRequestDispatcher}
-     * followed by a call to {@link RequestDispatcher#include}, the returned {@code
-     * HttpServletMapping} is the one corresponding to the path that caused the first {@code Servlet} in the invocation
-     * sequence to be invoked. If the currently active {@code Servlet} invocation was obtained by a call to
-     * {@link jakarta.servlet.AsyncContext#dispatch}, the returned {@code
-     * HttpServletMapping} is the one corresponding to the path that caused the first {@code Servlet} in the invocation
-     * sequence to be invoked. See {@link jakarta.servlet.RequestDispatcher#FORWARD_MAPPING},
+     * {@code HttpServletMapping} is the one corresponding to the path used to obtain the {@link RequestDispatcher}.
+     * If the currently active {@code Servlet} invocation was obtained by a call to
+     * {@link ServletRequest#getRequestDispatcher} followed by a call to {@link RequestDispatcher#include}, the returned
+     * {@code HttpServletMapping} is the one corresponding to the first {@code Servlet} in the invocation sequence that
+     * was invoked.
+     * If the currently active {@code Servlet} invocation was obtained by a call to
+     * {@link jakarta.servlet.AsyncContext#dispatch} or {@link jakarta.servlet.AsyncContext#dispatch(String)},
+     * the returned {@code HttpServletMapping} is the one corresponding to the first {@code Servlet} that will be invoked.
+     * See {@link jakarta.servlet.RequestDispatcher#FORWARD_MAPPING},
      * {@link jakarta.servlet.RequestDispatcher#INCLUDE_MAPPING} and {@link jakarta.servlet.AsyncContext#ASYNC_MAPPING} for
      * additional request attributes related to {@code HttpServletMapping}. If the currently active {@code Servlet}
      * invocation was obtained by a call to {@link jakarta.servlet.ServletContext#getNamedDispatcher}, the returned
@@ -190,9 +190,8 @@ public interface HttpServletRequest extends ServletRequest {
      * The returned object is immutable. Servlet 4.0 compliant implementations must override this method.
      * </p>
      * 
-     * @implSpec The default implementation returns a {@code
-     * HttpServletMapping} that returns the empty string for the match value, pattern and servlet name and {@code null}
-     *           for the match type.
+     * @implSpec The default implementation returns a {@code HttpServletMapping} that returns the empty string for
+     *           the match value, pattern and servlet name and {@code null} for the match type.
      *
      * @return An instance of {@code HttpServletMapping} describing the manner in which the current request was invoked.
      * 

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -166,44 +166,38 @@ public interface HttpServletRequest extends ServletRequest {
     public int getIntHeader(String name);
 
     /**
-     * Return the HttpServletMapping for the current dispatch of the request.
+     * Return the HttpServletMapping of the request.
      * <p>
      * The mapping returned depends on the current {@link jakarta.servlet.DispatcherType} as obtained from
      * {@link #getDispatcherType()}:
      *  <dl>
-     *   <dt>{@link jakarta.servlet.DispatcherType#REQUEST}</dt>
-     *   <dd>Return the mapping for the current {@code Servlet}.</dd>
-     *
-     *   <dt>{@link jakarta.servlet.DispatcherType#FORWARD}</dt>
-     *   <dd>If the {@link jakarta.servlet.RequestDispatcher} called was obtained
-     *       by {@link jakarta.servlet.ServletContext#getNamedDispatcher(String)} then
-     *       return the value that would have been returned prior to the call to 
-     *       {@link RequestDispatcher#forward(ServletRequest, ServletResponse)} 
-     *       i.e the value returned is unchanged by the forward call to a named dispatcher.
-     *       Otherwise return the mapping for the target of the dispatch 
-     *       i.e. the mapping for the current {@code Servlet}.</dd>
+     *   <dt>{@link jakarta.servlet.DispatcherType#REQUEST},
+     *   {@link jakarta.servlet.DispatcherType#ASYNC},
+     *   {@link jakarta.servlet.DispatcherType#ERROR}</dt>
+     *   <dd>Return the mapping for the target of the dispatch i.e. the mapping for the current
+     *       {@link jakarta.servlet.Servlet}.</dd>
      *
      *   <dt>{@link jakarta.servlet.DispatcherType#INCLUDE}</dt>
-     *   <dd>Return the value that would have been returned prior to the call to 
-     *       {@link RequestDispatcher#include(ServletRequest, ServletResponse)}
-     *       i.e the value returned is unchanged by the include call.</dd>
+     *   <dd>Return the mapping as prior to the current dispatch. 
+     *       i.e the mapping returned is unchanged by a call to</dd>
+     *       {@link RequestDispatcher#include(ServletRequest, ServletResponse)}.
      *
-     *   <dt>{@link jakarta.servlet.DispatcherType#ASYNC}</dt>
+     *   <dt>{@link jakarta.servlet.DispatcherType#FORWARD}</dt>
      *   <dd>Return the mapping for the target of the dispatch i.e. the mapping for the current
-     *       {@code Servlet}.</dd>
-     *
-     *   <dt>{@link jakarta.servlet.DispatcherType#ERROR}</dt>
-     *   <dd>Return the mapping for the target of the dispatch i.e. the mapping for the current
-     *       {@code Servlet}.</dd>
+     *       {@link jakarta.servlet.Servlet}, unless the {@link jakarta.servlet.RequestDispatcher} was 
+     *       obtained via {@link jakarta.servlet.ServletContext#getNamedDispatcher(String)},
+     *       in which case return the mapping as prior to the current dispatch. 
+     *       i.e the mapping returned is changed during a call to
+     *       {@link RequestDispatcher#forward(ServletRequest, ServletResponse)} only if  
+     *       the dispatcher is not a named dispatcher.</dd>
      *  </dl>
      * </p>
      * <p>
-     * Note: For dispatch types that return the mapping for the source of the dispatch, the lookup of the
-     * mapping for the dispatch source is recursive. For example:
+     * For example:
      *  <ul>
-     *   <li>For a sequence Servlet1-&gt;include-&gt;Servlet2-&gt;include-&gt;Servlet3, a call to this method in
+     *   <li>For a sequence Servlet1&nbsp;--include--&gt;&nbsp;Servlet2&nbsp;--include--&gt;&nbsp;Servlet3, a call to this method in
      *       Servlet3 will return the mapping for Servlet1.</li>
-     *   <li>For a sequence Servlet1-&gt;async-&gt;Servlet2-&gt;include-&gt;Servlet3, a call to this method in
+     *   <li>For a sequence Servlet1&nbsp;--async--&gt;&nbsp;Servlet2&nbsp;--named-forward--&gt;&nbsp;Servlet3, a call to this method in
      *       Servlet3 will return the mapping for Servlet2.</li>
      *  </ul>
      * </p>


### PR DESCRIPTION
For issue [2] of  #309

Reword the javadoc to align `getHttpServletMapping` under async dispatch to be similar to a `Dispatcher.forward(...)`.  The wording in this section is a bit cumbersome, but I've tried to add clarity without changing it too much.

Signed-off-by: Greg Wilkins <gregw@webtide.com>