### PR TITLE
Issue #225 doHead contentLength

### DIFF
--- a/api/src/test/java/jakarta/servlet/MockServletContext.java
+++ b/api/src/test/java/jakarta/servlet/MockServletContext.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jakarta.servlet;
+
+import jakarta.servlet.descriptor.JspConfigDescriptor;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.EventListener;
+import java.util.Map;
+import java.util.Set;
+
+public class MockServletContext implements ServletContext {
+    @Override
+    public String getContextPath() {
+        return null;
+    }
+
+    @Override
+    public ServletContext getContext(String uripath) {
+        return null;
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getEffectiveMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getEffectiveMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public String getMimeType(String file) {
+        return null;
+    }
+
+    @Override
+    public Set<String> getResourcePaths(String path) {
+        return null;
+    }
+
+    @Override
+    public URL getResource(String path) throws MalformedURLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String path) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getNamedDispatcher(String name) {
+        return null;
+    }
+
+    @Override
+    public Servlet getServlet(String name) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Servlet> getServlets() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getServletNames() {
+        return null;
+    }
+
+    @Override
+    public void log(String msg) {
+
+    }
+
+    @Override
+    public void log(Exception exception, String msg) {
+
+    }
+
+    @Override
+    public void log(String message, Throwable throwable) {
+
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        return null;
+    }
+
+    @Override
+    public String getServerInfo() {
+        return null;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        return null;
+    }
+
+    @Override
+    public boolean setInitParameter(String name, String value) {
+        return false;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String name, Object object) {
+
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+
+    }
+
+    @Override
+    public String getServletContextName() {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String servletName, String className) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String servletName, Servlet servlet) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addJspFile(String servletName, String jspFile) {
+        return null;
+    }
+
+    @Override
+    public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration getServletRegistration(String servletName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String filterName, String className) {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
+        return null;
+    }
+
+    @Override
+    public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration getFilterRegistration(String filterName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+        return null;
+    }
+
+    @Override
+    public SessionCookieConfig getSessionCookieConfig() {
+        return null;
+    }
+
+    @Override
+    public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {
+
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+        return null;
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+        return null;
+    }
+
+    @Override
+    public void addListener(String className) {
+
+    }
+
+    @Override
+    public <T extends EventListener> void addListener(T t) {
+
+    }
+
+    @Override
+    public void addListener(Class<? extends EventListener> listenerClass) {
+
+    }
+
+    @Override
+    public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public JspConfigDescriptor getJspConfigDescriptor() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public void declareRoles(String... roleNames) {
+
+    }
+
+    @Override
+    public String getVirtualServerName() {
+        return null;
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void setSessionTimeout(int sessionTimeout) {
+
+    }
+
+    @Override
+    public String getRequestCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setRequestCharacterEncoding(String encoding) {
+
+    }
+
+    @Override
+    public String getResponseCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setResponseCharacterEncoding(String encoding) {
+
+    }
+}

--- a/api/src/test/java/jakarta/servlet/MockServletOutputStream.java
+++ b/api/src/test/java/jakarta/servlet/MockServletOutputStream.java
@@ -1,0 +1,73 @@
+package jakarta.servlet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class MockServletOutputStream extends ServletOutputStream {
+    private final OutputStream out;
+
+    public MockServletOutputStream() {
+        this(null);
+    }
+
+    public MockServletOutputStream(OutputStream out) {
+        this.out = out == null ? new ByteArrayOutputStream() : out;
+    }
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public boolean isReady() {
+        return false;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+    }
+
+    public String takeOutputAsString() {
+        return takeOutputAsString(StandardCharsets.ISO_8859_1);
+    }
+
+    public String takeOutputAsString(Charset charset) {
+        byte[] bytes = takeOutput();
+        return bytes == null ? null : new String(bytes, charset);
+    }
+
+    public byte[] takeOutput() {
+        if (out instanceof ByteArrayOutputStream) {
+            ByteArrayOutputStream bout = (ByteArrayOutputStream) out;
+            byte[] bytes = bout.toByteArray();
+            bout.reset();
+            return bytes;
+        }
+        return null;
+    }
+}

--- a/api/src/test/java/jakarta/servlet/MockServletRequest.java
+++ b/api/src/test/java/jakarta/servlet/MockServletRequest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jakarta.servlet;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+
+public class MockServletRequest implements ServletRequest {
+    private final ServletContext context;
+
+    public MockServletRequest() {
+        this(new MockServletContext());
+    }
+
+    public MockServletRequest(ServletContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return null;
+    }
+
+    @Override
+    public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+
+    }
+
+    @Override
+    public int getContentLength() {
+        return 0;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        return 0;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getParameterNames() {
+        return null;
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        return new String[0];
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return null;
+    }
+
+    @Override
+    public String getProtocol() {
+        return "HTTP/1.0";
+    }
+
+    @Override
+    public String getScheme() {
+        return "http";
+    }
+
+    @Override
+    public String getServerName() {
+        return "host";
+    }
+
+    @Override
+    public int getServerPort() {
+        return 80;
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return null;
+    }
+
+    @Override
+    public String getRemoteAddr() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteHost() {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String name, Object o) {
+
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    @Override
+    public Enumeration<Locale> getLocales() {
+        return null;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return false;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return null;
+    }
+
+    @Override
+    public String getRealPath(String path) {
+        return null;
+    }
+
+    @Override
+    public int getRemotePort() {
+        return 0;
+    }
+
+    @Override
+    public String getLocalName() {
+        return null;
+    }
+
+    @Override
+    public String getLocalAddr() {
+        return null;
+    }
+
+    @Override
+    public int getLocalPort() {
+        return 8080;
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return context;
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) throws IllegalStateException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        return false;
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        return false;
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        return null;
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        return DispatcherType.REQUEST;
+    }
+}

--- a/api/src/test/java/jakarta/servlet/MockServletResponse.java
+++ b/api/src/test/java/jakarta/servlet/MockServletResponse.java
@@ -1,0 +1,124 @@
+package jakarta.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+public class MockServletResponse implements ServletResponse {
+    private ServletOutputStream servletOutputStream;
+    private PrintWriter printWriter;
+    private int bufferSize = 1024;
+
+    @Override
+    public String getCharacterEncoding() {
+        return StandardCharsets.ISO_8859_1.name();
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (printWriter != null)
+            throw new IllegalStateException();
+        if (servletOutputStream == null)
+            servletOutputStream = new MockServletOutputStream();
+        return servletOutputStream;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (printWriter != null)
+            return printWriter;
+        if (servletOutputStream != null)
+            throw new IllegalStateException();
+        printWriter = new PrintWriter(getOutputStream());
+        return printWriter;
+    }
+
+    @Override
+    public void setCharacterEncoding(String charset) {
+
+    }
+
+    @Override
+    public void setContentLength(int len) {
+        setContentLengthLong((long) len);
+    }
+
+    @Override
+    public void setContentLengthLong(long len) {
+
+    }
+
+    @Override
+    public void setContentType(String type) {
+
+    }
+
+    @Override
+    public void setBufferSize(int size) {
+        bufferSize = size;
+    }
+
+    @Override
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+
+    }
+
+    @Override
+    public void resetBuffer() {
+
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void setLocale(Locale loc) {
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+
+    public MockServletOutputStream getMockServletOutputStream() {
+        if (servletOutputStream instanceof MockServletOutputStream)
+            return (MockServletOutputStream) servletOutputStream;
+        return null;
+    }
+}

--- a/api/src/test/java/jakarta/servlet/http/HttpServletTest.java
+++ b/api/src/test/java/jakarta/servlet/http/HttpServletTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jakarta.servlet.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import jakarta.servlet.MockServletOutputStream;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class HttpServletTest {
+
+    public interface Handler {
+        void handle(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException;
+    }
+
+    @ParameterizedTest
+    @MethodSource("headTest")
+    public void testHead(String test, Handler doGet, boolean expectedFlushed, long expectedContentLength)
+            throws ServletException, IOException {
+        HttpServlet servlet = new HttpServlet() {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+                doGet.handle(request, response);
+            }
+        };
+
+        MockHttpServletRequest request = new MockHttpServletRequest() {
+            @Override
+            public String getMethod() {
+                return "HEAD";
+            }
+        };
+
+        AtomicBoolean committed = new AtomicBoolean();
+        AtomicLong contentLength = new AtomicLong(-1);
+        MockHttpServletResponse response = new MockHttpServletResponse() {
+            @Override
+            public void flushBuffer() throws IOException {
+                committed.set(true);
+            }
+
+            @Override
+            public boolean isCommitted() {
+                return committed.get();
+            }
+
+            @Override
+            public void setContentLengthLong(long len) {
+                contentLength.set(len);
+            }
+        };
+
+        servlet.service(request, response);
+        MockServletOutputStream out = response.getMockServletOutputStream();
+        String actual = out == null ? null : out.takeOutputAsString();
+
+        // Check if the output should have already been flushed
+        assertThat(test, committed.get(), is(expectedFlushed));
+        assertThat(test, contentLength.get(), is(expectedContentLength));
+        assertThat(test, actual, anyOf(is(""), nullValue()));
+    }
+
+    public static Stream<Arguments> headTest() {
+        return Stream.of(
+                Arguments.of("Nothing output",
+                        (Handler) (request, response) -> {
+                        }, false, 0),
+
+                Arguments.of("Output smaller than buffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(2048);
+                            response.getOutputStream().print("Hello World");
+                        }, false, 11),
+
+                Arguments.of("Write smaller than buffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(2048);
+                            response.getWriter().print("Hello World");
+                        }, false, 11),
+
+                Arguments.of("Output bigger than buffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(5);
+                            response.getOutputStream().print("Hello World");
+                        }, true, -1),
+
+                Arguments.of("Write bigger than buffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(5);
+                            response.getWriter().print("Hello World");
+                        }, true, -1),
+
+                Arguments.of("Outputs with Content-Length smaller than buffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(1024);
+                            response.setContentLength(11);
+                            response.getOutputStream().print("Hello World");
+                        }, true, 11),
+
+                Arguments.of("Write with Content-Length smaller than buffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(1024);
+                            response.setContentLength(11);
+                            response.getWriter().print("Hello World");
+                        }, true, 11),
+
+                Arguments.of("Output with resetBuffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(2048);
+                            response.getOutputStream().print("THIS IS WRONG");
+                            response.resetBuffer();
+                            response.getOutputStream().print("Hello World");
+                        }, false, 11),
+
+                Arguments.of("Write with resetBuffer",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(2048);
+                            response.getWriter().print("THIS IS WRONG");
+                            response.resetBuffer();
+                            response.getWriter().print("Hello World");
+                        }, false, 11),
+
+                Arguments.of("Output with reset",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(2048);
+                            response.getWriter().print("THIS IS WRONG");
+                            response.reset();
+                            response.getOutputStream().print("Hello World");
+                        }, false, 11),
+
+                Arguments.of("Write with reset",
+                        (Handler) (request, response) -> {
+                            response.setBufferSize(2048);
+                            response.getOutputStream().print("THIS IS WRONG");
+                            response.reset();
+                            response.getWriter().print("Hello World");
+                        }, false, 11)
+
+        );
+    }
+}

--- a/api/src/test/java/jakarta/servlet/http/MockHttpServletRequest.java
+++ b/api/src/test/java/jakarta/servlet/http/MockHttpServletRequest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jakarta.servlet.http;
+
+import jakarta.servlet.MockServletRequest;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Enumeration;
+
+public class MockHttpServletRequest extends MockServletRequest implements HttpServletRequest {
+    public MockHttpServletRequest() {
+    }
+
+    public MockHttpServletRequest(ServletContext context) {
+        super(context);
+    }
+
+    @Override
+    public String getAuthType() {
+        return null;
+    }
+
+    @Override
+    public Cookie[] getCookies() {
+        return new Cookie[0];
+    }
+
+    @Override
+    public long getDateHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getHeaderNames() {
+        return null;
+    }
+
+    @Override
+    public int getIntHeader(String name) {
+        return 0;
+    }
+
+    @Override
+    public String getMethod() {
+        return "GET";
+    }
+
+    @Override
+    public String getPathInfo() {
+        return null;
+    }
+
+    @Override
+    public String getPathTranslated() {
+        return null;
+    }
+
+    @Override
+    public String getContextPath() {
+        return null;
+    }
+
+    @Override
+    public String getQueryString() {
+        return null;
+    }
+
+    @Override
+    public String getRemoteUser() {
+        return null;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return false;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public String getRequestedSessionId() {
+        return null;
+    }
+
+    @Override
+    public String getRequestURI() {
+        return null;
+    }
+
+    @Override
+    public StringBuffer getRequestURL() {
+        return null;
+    }
+
+    @Override
+    public String getServletPath() {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession(boolean create) {
+        return null;
+    }
+
+    @Override
+    public HttpSession getSession() {
+        return null;
+    }
+
+    @Override
+    public String changeSessionId() {
+        return null;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdValid() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromCookie() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromURL() {
+        return false;
+    }
+
+    @Override
+    public boolean isRequestedSessionIdFromUrl() {
+        return false;
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        return false;
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+
+    }
+
+    @Override
+    public void logout() throws ServletException {
+
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        return null;
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
+        return null;
+    }
+}

--- a/api/src/test/java/jakarta/servlet/http/MockHttpServletResponse.java
+++ b/api/src/test/java/jakarta/servlet/http/MockHttpServletResponse.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ * Copyright 2004 The Apache Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jakarta.servlet.http;
+
+import jakarta.servlet.MockServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+
+public class MockHttpServletResponse extends MockServletResponse implements HttpServletResponse {
+    @Override
+    public void addCookie(Cookie cookie) {
+
+    }
+
+    @Override
+    public boolean containsHeader(String name) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectURL(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeUrl(String url) {
+        return null;
+    }
+
+    @Override
+    public String encodeRedirectUrl(String url) {
+        return null;
+    }
+
+    @Override
+    public void sendError(int sc, String msg) throws IOException {
+
+    }
+
+    @Override
+    public void sendError(int sc) throws IOException {
+
+    }
+
+    @Override
+    public void sendRedirect(String location) throws IOException {
+
+    }
+
+    @Override
+    public void setDateHeader(String name, long date) {
+
+    }
+
+    @Override
+    public void addDateHeader(String name, long date) {
+
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+
+    }
+
+    @Override
+    public void addHeader(String name, String value) {
+
+    }
+
+    @Override
+    public void setIntHeader(String name, int value) {
+
+    }
+
+    @Override
+    public void addIntHeader(String name, int value) {
+
+    }
+
+    @Override
+    public void setStatus(int sc) {
+
+    }
+
+    @Override
+    public void setStatus(int sc, String sm) {
+
+    }
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getHeaders(String name) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        return null;
+    }
+}


### PR DESCRIPTION
Fix #225 by:
 + converting the contentLength field to a long
 + checking against bufferSize before setting a content length to simulate a buffer overflow
 + support flush and close
 + pass through async IO listener