### PR TITLE
Fix #365 - correct fragment order in example 2

### DIFF
--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -3994,7 +3994,7 @@ following:
 * E, B, F, <no id>, C, D
 * E, B, F, <no id>, D, C
 * E, B, F, D, <no id>, C
-* E, B, F, D, <no id>, D
+* B, E, F, D, <no id>, C
 
 --
 


### PR DESCRIPTION
Signed-off-by: Mark Thomas <markt@apache.org>