### PR TITLE
Provide defaults for deprecated methods

### DIFF
--- a/api/src/main/java/jakarta/servlet/ServletContext.java
+++ b/api/src/main/java/jakarta/servlet/ServletContext.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
+ * Copyright (c) 2020 Payara Services Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +27,7 @@ import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.Map;
 import java.util.Set;
+import java.util.Vector;
 
 /**
  * Defines a set of methods that a servlet uses to communicate with its servlet container, for example, to get the MIME
@@ -361,11 +363,11 @@ public interface ServletContext {
      * shared business logic by invoking methods on common non-servlet classes.
      *
      * @param name the servlet name
-     * @return the {@code jakarta.servlet.Servlet Servlet} with the given name
+     * @return {@code null}
      * @throws ServletException if an exception has occurred that interfaces with servlet's normal operation
      */
     @Deprecated
-    public Servlet getServlet(String name) throws ServletException;
+    default public Servlet getServlet(String name) throws ServletException {return null;}
 
     /**
      * @deprecated As of Java Servlet API 2.0, with no replacement.
@@ -378,7 +380,7 @@ public interface ServletContext {
      * @return an <code>Enumeration</code> of {@code jakarta.servlet.Servlet Servlet}
      */
     @Deprecated
-    public Enumeration<Servlet> getServlets();
+    default public Enumeration<Servlet> getServlets() { return new Vector<Servlet>().elements();}
 
     /**
      * @deprecated As of Java Servlet API 2.1, with no replacement.
@@ -391,7 +393,7 @@ public interface ServletContext {
      * @return an <code>Enumeration</code> of {@code jakarta.servlet.Servlet Servlet} names
      */
     @Deprecated
-    public Enumeration<String> getServletNames();
+    default public Enumeration<String> getServletNames() { return new Vector<String>().elements();}
 
     /**
      *
@@ -413,7 +415,7 @@ public interface ServletContext {
      * @param msg a <code>String</code> that describes the exception
      */
     @Deprecated
-    public void log(Exception exception, String msg);
+    default public void log(Exception exception, String msg) { log (msg, exception); }
 
     /**
      * Writes an explanatory message and a stack trace for a given <code>Throwable</code> exception to the servlet log file.

--- a/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpServletRequest.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
+ * Copyright (c) 2020 Payara Services Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -517,7 +518,7 @@ public interface HttpServletRequest extends ServletRequest {
      * <code>false</code>
      */
     @Deprecated
-    public boolean isRequestedSessionIdFromUrl();
+    default public boolean isRequestedSessionIdFromUrl() { return isRequestedSessionIdFromURL(); }
 
     /**
      * Use the container login mechanism configured for the <code>ServletContext</code> to authenticate the user making this

--- a/api/src/main/java/jakarta/servlet/http/HttpSessionContext.java
+++ b/api/src/main/java/jakarta/servlet/http/HttpSessionContext.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1997, 2020 Oracle and/or its affiliates and others.
  * All rights reserved.
  * Copyright 2004 The Apache Software Foundation
+ * Copyright (c) 2020 Payara Services Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +45,7 @@ public interface HttpSessionContext {
      * @return null in all cases
      */
     @Deprecated
-    public HttpSession getSession(String sessionId);
+    default public HttpSession getSession(String sessionId) {return null; }
 
     /**
      *
@@ -55,5 +56,5 @@ public interface HttpSessionContext {
      *
      */
     @Deprecated
-    public Enumeration<String> getIds();
+    default public Enumeration<String> getIds() {return null; }
 }


### PR DESCRIPTION
These methods all already specify that they return either null or
an empty enumeration so they are now provided by default for easier
removal later.

Based off comments in #371 