### PR TITLE
Update maven-bundle-plugin to latest to fix CI failure with newer JREs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -181,7 +181,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.1</version>
                 <configuration>
                     <supportedProjectTypes>
                         <supportedProjectType>jar</supportedProjectType>


### PR DESCRIPTION
The previous version of the plug-in triggers a
ConcurrentModificationException on newer JREs. The likely root cause is
https://hg.openjdk.java.net/jdk/jdk/rev/65b345254ca3
The newer maven-bundle-plugin has been updated to avoid the issue.

Signed-off-by: Mark Thomas <markt@apache.org>