### PR TITLE
Add Cookie#setAttribute 

### DIFF
--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -469,7 +469,7 @@ public class Cookie implements Cloneable, Serializable {
             throw new IllegalArgumentException(createErrorMessage("err.cookie_attribute_name_is_token", name));
         }
 
-        if (containsReservedToken(value)) {
+        if (value != null && containsReservedToken(value)) {
             throw new IllegalArgumentException(createErrorMessage("err.cookie_attribute_value_is_token", value));
         }
 

--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -455,8 +455,8 @@ public class Cookie implements Cloneable, Serializable {
      * 
      * @param value the value of the cookie attribute associated with the given name, can be {@code null}
      *
-     * @throws IllegalArgumentException if the cookie attribute name is null or empty, or if either the cookie attribute name or value
-     * contains any illegal characters (for example, a comma, space, or semicolon) or matches a token reserved for use by the cookie protocol
+     * @throws IllegalArgumentException if the cookie name is null or empty or contains any illegal characters (for example,
+     * a comma, space, or semicolon) or matches a token reserved for use by the cookie protocol
      * 
      * @since Servlet 5.1
      */
@@ -467,10 +467,6 @@ public class Cookie implements Cloneable, Serializable {
 
         if (containsReservedToken(name)) {
             throw new IllegalArgumentException(createErrorMessage("err.cookie_attribute_name_is_token", name));
-        }
-
-        if (value != null && containsReservedToken(value)) {
-            throw new IllegalArgumentException(createErrorMessage("err.cookie_attribute_value_is_token", value));
         }
 
         attributes.put(name, value);

--- a/api/src/main/java/jakarta/servlet/http/LocalStrings.properties
+++ b/api/src/main/java/jakarta/servlet/http/LocalStrings.properties
@@ -19,8 +19,11 @@
 # Default localized string information
 # Localized for Locale en_US
 
-err.cookie_name_is_token=Cookie name \"{0}\" is a reserved token
+err.cookie_name_is_token=Cookie name \"{0}\" contains a reserved token
 err.cookie_name_blank=Cookie name must not be null or empty
+err.cookie_attribute_name_is_token=Cookie attribute name \"{0}\" contains a reserved token
+err.cookie_attribute_name_blank=Cookie attribute name must not be null or empty
+err.cookie_attribute_value_is_token=Cookie attribute value \"{0}\" contains a reserved token
 err.io.nullArray=Null passed for byte array in write method
 err.io.indexOutOfBounds=Invalid offset [{0}] and / or length [{1}] specified for array of size [{2}]
 err.io.short_read=Short Read

--- a/api/src/main/java/jakarta/servlet/http/LocalStrings.properties
+++ b/api/src/main/java/jakarta/servlet/http/LocalStrings.properties
@@ -23,7 +23,6 @@ err.cookie_name_is_token=Cookie name \"{0}\" contains a reserved token
 err.cookie_name_blank=Cookie name must not be null or empty
 err.cookie_attribute_name_is_token=Cookie attribute name \"{0}\" contains a reserved token
 err.cookie_attribute_name_blank=Cookie attribute name must not be null or empty
-err.cookie_attribute_value_is_token=Cookie attribute value \"{0}\" contains a reserved token
 err.io.nullArray=Null passed for byte array in write method
 err.io.indexOutOfBounds=Invalid offset [{0}] and / or length [{1}] specified for array of size [{2}]
 err.io.short_read=Short Read


### PR DESCRIPTION
For discussion, see #175 and #271

While at it I also took opportunity to:
- cleanup `isToken` helper method whose comment and methodname were completely out of sync with actual implementation
- fix "rfc2019" typo in comments to "rfc2109"
- add missing check for "HttpOnly" in cookie name
- removed outdated javadoc wrt version 1 being "experimental"