### PR TITLE
Update maven spec dependencies, specifically of asciidoc

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -33,9 +33,9 @@
     <properties>
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
-        <asciidoctorj.version>2.4.0</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
-        <jruby.version>9.2.12.0</jruby.version>
+        <asciidoctorj.version>2.5.2</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
+        <jruby.version>9.3.1.0</jruby.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M3</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>2.0.0-RC.1</version>
+                <version>2.2.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.jruby</groupId>
@@ -118,8 +118,11 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
+                            <sourceDirectory>${basedir}/src/main/asciidoc</sourceDirectory>
                             <outputFile>${project.build.directory}/generated-docs/jakarta-servlet-spec-${spec.version}.html</outputFile>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
+                                <imagesdir>images</imagesdir>
                                 <doctype>book</doctype>
                                 <status>${status}</status>
                                 <data-uri />
@@ -141,8 +144,11 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
+                            <sourceDirectory>${basedir}/src/main/asciidoc</sourceDirectory>
                             <outputFile>${project.build.directory}/generated-docs/jakarta-servlet-spec-${spec.version}.pdf</outputFile>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
+                                <imagesdir>images</imagesdir>
                                 <pdf-stylesdir>${project.basedir}/src/main/theme</pdf-stylesdir>
                                 <pdf-style>jakartaee</pdf-style>
                                 <doctype>book</doctype>
@@ -163,7 +169,6 @@
                 </executions>
                 <configuration>
                     <sourceDocumentName>servlet-spec.adoc</sourceDocumentName>
-                    <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>
                         <revnumber>${spec.version}</revnumber>
                         <revremark>${status}</revremark>


### PR DESCRIPTION
Some required config changes due to breaking changes in v2.

See https://docs.asciidoctor.org/maven-tools/latest/plugin/v2-migration-guide/

Signed-off-by: arjantijms <arjan.tijms@gmail.com>