### PR TITLE
Add a module-info.java

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -249,9 +249,6 @@
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                        <manifestEntries>
-                            <Automatic-Module-Name>jakarta.servlet</Automatic-Module-Name>
-                        </manifestEntries>
                     </archive>
                     <excludes>
                         <exclude>**/*.java</exclude>

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -19,8 +19,5 @@ module jakarta.servlet {
     exports jakarta.servlet.descriptor;
     exports jakarta.servlet.http;
     
-    opens jakarta.servlet;
-    opens jakarta.servlet.annotation;
-    opens jakarta.servlet.descriptor;
-    opens jakarta.servlet.http;
+    opens jakarta.servlet.resources;
 }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+module jakarta.servlet {
+    exports jakarta.servlet;
+    exports jakarta.servlet.annotation;
+    exports jakarta.servlet.descriptor;
+    exports jakarta.servlet.http;
+    
+    opens jakarta.servlet;
+    opens jakarta.servlet.annotation;
+    opens jakarta.servlet.descriptor;
+    opens jakarta.servlet.http;
+}

--- a/api/src/test/java/jakarta/servlet/http/CookieTest.java
+++ b/api/src/test/java/jakarta/servlet/http/CookieTest.java
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class CookieTest {
+public class CookieTest {
     @Test
-    void testCookie() {
+    public void testCookie() {
         Cookie cookie = new Cookie("name", "value");
         assertThat(cookie.getName(), is("name"));
         assertThat(cookie.getValue(), is("value"));
@@ -56,12 +56,12 @@ class CookieTest {
             "domain",
             "\377",
     })
-    void testBadCookie(String name) {
+    public void testBadCookie(String name) {
         assertThrows(IllegalArgumentException.class, () -> new Cookie(name, "value"));
     }
 
     @Test
-    void testComment() {
+    public void testComment() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setComment("comment");
         assertThat(cookie.getComment(), is("comment"));
@@ -77,7 +77,7 @@ class CookieTest {
     }
 
     @Test
-    void testDomain() {
+    public void testDomain() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setDomain("domain");
         assertThat(cookie.getDomain(), is("domain"));
@@ -93,7 +93,7 @@ class CookieTest {
     }
 
     @Test
-    void testMaxAge() {
+    public void testMaxAge() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setMaxAge(100);
         assertThat(cookie.getMaxAge(), is(100));
@@ -112,7 +112,7 @@ class CookieTest {
     }
 
     @Test
-    void testPath() {
+    public void testPath() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setPath("path");
         assertThat(cookie.getPath(), is("path"));
@@ -128,7 +128,7 @@ class CookieTest {
     }
 
     @Test
-    void testSecure() {
+    public void testSecure() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setSecure(true);
         assertThat(cookie.getSecure(), is(true));
@@ -150,7 +150,7 @@ class CookieTest {
     }
 
     @Test
-    void testValue() {
+    public void testValue() {
         Cookie cookie = new Cookie("name", "value");
         assertThat(cookie.getName(), is("name"));
         assertThat(cookie.getValue(), is("value"));
@@ -161,7 +161,7 @@ class CookieTest {
     }
 
     @Test
-    void testVersion() {
+    public void testVersion() {
         Cookie cookie = new Cookie("name", "value");
         assertThat(cookie.getVersion(), is(0));
         cookie.setVersion(1);
@@ -173,7 +173,7 @@ class CookieTest {
     }
 
     @Test
-    void testHttpOnly() {
+    public void testHttpOnly() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setHttpOnly(true);
         assertThat(cookie.isHttpOnly(), is(true));
@@ -195,7 +195,7 @@ class CookieTest {
     }
 
     @Test
-    void testAttribute() {
+    public void testAttribute() {
         Cookie cookie = new Cookie("name", "value");
         assertThat(cookie.getAttributes().size(), is(0));
         assertThat(cookie.getAttribute("A0"), nullValue());
@@ -225,13 +225,13 @@ class CookieTest {
             " ",
             "\377",
     })
-    void testBadAttribute(String name) {
+    public void testBadAttribute(String name) {
         Cookie cookie = new Cookie("name", "value");
         assertThrows(IllegalArgumentException.class, () -> cookie.setAttribute(name, "value"));
     }
 
     @Test
-    void testCloneHashEquals() {
+    public void testCloneHashEquals() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setComment("comment");
         cookie.setDomain("domain");

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -8567,6 +8567,13 @@ Remove API classes and methods that were deprecated in Servlet 5.0 and earlier.
 This includes removing the `SingleThreadModel` and `HttpSessionContext`
 interfaces and the `HttpUtils` class as well as various deprecated methods.
 
+link:https://github.com/eclipse-ee4j/servlet-api/issues/201[Issue 201]::
+Add a `module-info.java` to support using the Servlet API in a modular
+environment as per the Java module system and the Jakarta EE 10 
+link:https://github.com/jakartaee/specification-committee/blob/master/names.adoc[recommendations] 
+
+
+
 === Compatibility with Jakarta Servlet Specification Version 4.0
 Jakarta Servlet version 5.0 is only a change of namespaces
 (see <<Changes Since Jakarta Servlet 4.0>>).


### PR DESCRIPTION
Fixes #201

Module name is `jakarta.servlet` (Per the naming [conventions](https://github.com/jakartaee/specification-committee/blob/master/names.adoc))
Exports the 4 API packages

Opens the 4 API packages as well to prevent errors like:

```
[ERROR] jakarta.servlet.http.CookieTest.testValue  Time elapsed: 0 s  <<< ERROR!

java.lang.reflect.InaccessibleObjectException: 
    Unable to make jakarta.servlet.http.CookieTest() accessible: 
        module jakarta.servlet does not "opens jakarta.servlet.http" to unnamed module @ffaa6af
```

Signed-off-by: arjantijms <arjan.tijms@gmail.com>