### PR TITLE
Fix #37 - update Cookie class for RFC 6265

### DIFF
--- a/api/src/main/java/jakarta/servlet/SessionCookieConfig.java
+++ b/api/src/main/java/jakarta/servlet/SessionCookieConfig.java
@@ -109,31 +109,33 @@ public interface SessionCookieConfig {
     public String getPath();
 
     /**
-     * Sets the comment that will be assigned to any session tracking cookies created on behalf of the application
-     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
-     *
+     * With the adoption of support for RFC 6265, this method should no longer be used.
      * <p>
-     * As a side effect of this call, the session tracking cookies will be marked with a <code>Version</code> attribute
-     * equal to <code>1</code>.
+     * If called, this method has no effect.
      * 
-     * @param comment the cookie comment to use
+     * @param comment ignore
      *
      * @throws IllegalStateException if the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was
      * acquired has already been initialized
      *
      * @see jakarta.servlet.http.Cookie#setComment(String)
      * @see jakarta.servlet.http.Cookie#getVersion
+     * 
+     * @deprecated This is no longer required with RFC 6265
      */
+    @Deprecated(since = "Servlet 6.0", forRemoval = true)
     public void setComment(String comment);
 
     /**
-     * Gets the comment that will be assigned to any session tracking cookies created on behalf of the application
-     * represented by the <tt>ServletContext</tt> from which this <tt>SessionCookieConfig</tt> was acquired.
+     * With the adoption of support for RFC 6265, this method should no longer be used.
      *
-     * @return the cookie comment set via {@link #setComment}, or <tt>null</tt> if {@link #setComment} was never called
+     * @return Always {@code null}
      *
      * @see jakarta.servlet.http.Cookie#getComment()
+     * 
+     * @deprecated This is no longer required with RFC 6265
      */
+    @Deprecated(since = "Servlet 6.0", forRemoval = true)
     public String getComment();
 
     /**

--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -67,7 +67,6 @@ public class Cookie implements Cloneable, Serializable {
 
     private static final String LSTRING_FILE = "jakarta.servlet.http.LocalStrings";
 
-    private static final String COMMENT = "Comment"; // ;Comment=VALUE ... describes cookie's use
     private static final String DOMAIN = "Domain"; // ;Domain=VALUE ... domain that sees cookie
     private static final String MAX_AGE = "Max-Age"; // ;Max-Age=VALUE ... cookies auto-expire
     private static final String PATH = "Path"; // ;Path=VALUE ... URLs that see the cookie
@@ -139,26 +138,33 @@ public class Cookie implements Cloneable, Serializable {
     }
 
     /**
-     * Specifies a comment that describes a cookie's purpose. The comment is useful if the browser presents the cookie to
-     * the user. Comments are not supported by Netscape Version 0 cookies.
+     * With the adoption of support for RFC 6265, this method should no longer be used.
+     * <p>
+     * If called, this method has no effect.
      *
-     * @param purpose a <code>String</code> specifying the comment to display to the user
+     * @param purpose This parameter is ignored
      *
      * @see #getComment
+     * 
+     * @deprecated This is no longer required with RFC 6265
      */
+    @Deprecated(since = "Servlet 6.0", forRemoval = true)
     public void setComment(String purpose) {
-        putAttribute(COMMENT, purpose);
+        // NO-OP
     }
 
     /**
-     * Returns the comment describing the purpose of this cookie, or <code>null</code> if the cookie has no comment.
+     * With the adoption of support for RFC 6265, this method should no longer be used.
      *
-     * @return the comment of the cookie, or <code>null</code> if unspecified
+     * @return Always {@code null}
      *
      * @see #setComment
+     * 
+     * @deprecated This is no longer required with RFC 6265
      */
+    @Deprecated(since = "Servlet 6.0", forRemoval = true)
     public String getComment() {
-        return getAttribute(COMMENT);
+        return null;
     }
 
     /**

--- a/api/src/main/java/jakarta/servlet/http/Cookie.java
+++ b/api/src/main/java/jakarta/servlet/http/Cookie.java
@@ -55,8 +55,7 @@ import java.util.TreeMap;
  * with this class. This class does not support the cache control defined with HTTP 1.1.
  *
  * <p>
- * This class supports both the Version 0 (by Netscape) and Version 1 (by RFC 2109) cookie specifications. By default,
- * cookies are created using Version 0 to ensure the best interoperability.
+ * This class supports cookies as defined by <a href="http://www.ietf.org/rfc/rfc6265.txt">RFC 6265</a>.
  *
  * @author Various
  */
@@ -96,7 +95,6 @@ public class Cookie implements Cloneable, Serializable {
     //
     private final String name; // NAME= ... "$Name" style is reserved
     private String value; // value of NAME
-    private int version = 0; // ;Version=1 ... means RFC 2109++ style
 
     //
     // Attributes encoded in the header's cookie fields.
@@ -107,7 +105,7 @@ public class Cookie implements Cloneable, Serializable {
      * Constructs a cookie with the specified name and value.
      *
      * <p>
-     * The name must conform to RFC 2109. However, vendors may provide a configuration option that allows cookie names
+     * The name must conform to RFC 6265. However, vendors may provide a configuration option that allows cookie names
      * conforming to the original Netscape Cookie Specification to be accepted.
      *
      * <p>
@@ -116,10 +114,6 @@ public class Cookie implements Cloneable, Serializable {
      * <p>
      * The value can be anything the server chooses to send. Its value is probably of interest only to the server. The
      * cookie's value can be changed after creation with the <code>setValue</code> method.
-     *
-     * <p>
-     * By default, cookies are created according to the Netscape cookie specification. The version can be changed with the
-     * <code>setVersion</code> method.
      *
      * @param name the name of the cookie
      *
@@ -136,16 +130,7 @@ public class Cookie implements Cloneable, Serializable {
             throw new IllegalArgumentException(createErrorMessage("err.cookie_name_blank"));
         }
 
-        if (hasReservedCharacters(name) || name.startsWith("$")
-                || name.equalsIgnoreCase(COMMENT) // rfc2109
-                || name.equalsIgnoreCase("Discard") // 2109++
-                || name.equalsIgnoreCase(DOMAIN)
-                || name.equalsIgnoreCase("Expires") // (old cookies)
-                || name.equalsIgnoreCase(MAX_AGE) // rfc2109
-                || name.equalsIgnoreCase(PATH)
-                || name.equalsIgnoreCase(SECURE)
-                || name.equalsIgnoreCase("Version")
-                || name.equalsIgnoreCase(HTTP_ONLY)) {
+        if (hasReservedCharacters(name)) {
             throw new IllegalArgumentException(createErrorMessage("err.cookie_name_invalid", name));
         }
 
@@ -181,12 +166,12 @@ public class Cookie implements Cloneable, Serializable {
      * Specifies the domain within which this cookie should be presented.
      *
      * <p>
-     * The form of the domain name is specified by RFC 2109. A domain name begins with a dot (<code>.foo.com</code>) and
+     * The form of the domain name is specified by RFC 6265. A domain name begins with a dot (<code>.foo.com</code>) and
      * means that the cookie is visible to servers in a specified Domain Name System (DNS) zone (for example,
      * <code>www.foo.com</code>, but not <code>a.b.foo.com</code>). By default, cookies are only returned to the server that
      * sent them.
      *
-     * @param domain the domain name within which this cookie is visible; form is according to RFC 2109
+     * @param domain the domain name within which this cookie is visible; form is according to RFC 6265
      *
      * @see #getDomain
      */
@@ -198,7 +183,7 @@ public class Cookie implements Cloneable, Serializable {
      * Gets the domain name of this Cookie.
      *
      * <p>
-     * Domain names are formatted according to RFC 2109.
+     * Domain names are formatted according to RFC 6265.
      *
      * @return the domain name of this Cookie
      *
@@ -253,7 +238,8 @@ public class Cookie implements Cloneable, Serializable {
      * makes the cookie visible to all directories on the server under <i>/catalog</i>.
      *
      * <p>
-     * Consult RFC 2109 (available on the Internet) for more information on setting path names for cookies.
+     * Consult <a href="http://www.ietf.org/rfc/rfc6265.txt">RFC 6265</a> for more information on setting path names for
+     * cookies.
      *
      *
      * @param uri a <code>String</code> specifying a path
@@ -343,31 +329,33 @@ public class Cookie implements Cloneable, Serializable {
     }
 
     /**
-     * Returns the version of the protocol this cookie complies with. Version 1 complies with RFC 2109, and version 0
-     * complies with the original cookie specification drafted by Netscape. Cookies provided by a browser use and identify
-     * the browser's cookie version.
+     * With the adoption of support for RFC 6265, this method should no longer be used.
      * 
-     * @return 0 if the cookie complies with the original Netscape specification; 1 if the cookie complies with RFC 2109
+     * @return Always 0
      *
      * @see #setVersion
+     * 
+     * @deprecated This is no longer required with RFC 6265
      */
+    @Deprecated(since = "Servlet 6.0", forRemoval = true)
     public int getVersion() {
-        return version;
+        return 0;
     }
 
     /**
-     * Sets the version of the cookie protocol that this Cookie complies with.
-     *
+     * With the adoption of support for RFC 6265, this method should no longer be used.
      * <p>
-     * Version 0 complies with the original Netscape cookie specification. Version 1 complies with RFC 2109.
+     * If called, this method has no effect.
      *
-     * @param v 0 if the cookie should comply with the original Netscape specification; 1 if the cookie should comply with
-     * RFC 2109
+     * @param v This parameter is ignored
      *
      * @see #getVersion
+     * 
+     * @deprecated This is no longer required with RFC 6265
      */
+    @Deprecated(since = "Servlet 6.0", forRemoval = true)
     public void setVersion(int v) {
-        version = v;
+        // NO-OP
     }
 
     /*
@@ -526,7 +514,7 @@ public class Cookie implements Cloneable, Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, value, attributes) + version;
+        return Objects.hash(name, value, attributes);
     }
 
     @Override
@@ -543,6 +531,6 @@ public class Cookie implements Cloneable, Serializable {
 
     @Override
     public String toString() {
-        return String.format("%s{%s=%s,%d,%s}", super.toString(), name, value, version, attributes);
+        return String.format("%s{%s=%s,%s}", super.toString(), name, value, attributes);
     }
 }

--- a/api/src/test/java/jakarta/servlet/http/CookieTest.java
+++ b/api/src/test/java/jakarta/servlet/http/CookieTest.java
@@ -58,18 +58,18 @@ public class CookieTest {
         assertThrows(IllegalArgumentException.class, () -> new Cookie(name, "value"));
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testComment() {
         Cookie cookie = new Cookie("name", "value");
         cookie.setComment("comment");
-        assertThat(cookie.getComment(), is("comment"));
-        assertThat(cookie.getAttributes().keySet(), contains("Comment"));
-        assertThat(cookie.getAttributes().values(), contains("comment"));
+        assertThat(cookie.getComment(), nullValue());
+        assertThat(cookie.getAttributes().size(), is(0));
         cookie.setAttribute("COMMENT", "Comment!");
-        assertThat(cookie.getComment(), is("Comment!"));
-        assertThat(cookie.getAttributes().keySet(), contains("Comment"));
+        assertThat(cookie.getComment(), nullValue());
+        assertThat(cookie.getAttributes().keySet(), contains("COMMENT"));
         assertThat(cookie.getAttributes().values(), contains("Comment!"));
-        cookie.setComment(null);
+        cookie.setAttribute("COMMENT", null);
         assertThat(cookie.getComment(), nullValue());
         assertThat(cookie.getAttributes().size(), is(0));
     }
@@ -232,7 +232,6 @@ public class CookieTest {
     @Test
     public void testCloneHashEquals() {
         Cookie cookie = new Cookie("name", "value");
-        cookie.setComment("comment");
         cookie.setDomain("domain");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(10);
@@ -245,7 +244,6 @@ public class CookieTest {
 
         assertThat(clone.getName(), is("name"));
         assertThat(clone.getValue(), is("value"));
-        assertThat(clone.getComment(), is("comment"));
         assertThat(clone.getDomain(), is("domain"));
         assertThat(clone.getMaxAge(), is(10));
         assertThat(clone.getPath(), is("/path"));

--- a/api/src/test/java/jakarta/servlet/http/CookieTest.java
+++ b/api/src/test/java/jakarta/servlet/http/CookieTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class CookieTest {
+    @SuppressWarnings("removal")
     @Test
     public void testCookie() {
         Cookie cookie = new Cookie("name", "value");
@@ -51,9 +52,6 @@ public class CookieTest {
             "=",
             " ",
             "name=value",
-            "$name",
-            "comment",
-            "domain",
             "\377",
     })
     public void testBadCookie(String name) {
@@ -160,15 +158,16 @@ public class CookieTest {
         assertThat(cookie.getValue(), nullValue());
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testVersion() {
         Cookie cookie = new Cookie("name", "value");
         assertThat(cookie.getVersion(), is(0));
         cookie.setVersion(1);
-        assertThat(cookie.getVersion(), is(1));
+        assertThat(cookie.getVersion(), is(0));
         assertThat(cookie.getAttributes().size(), is(0));
         cookie.setVersion(Integer.MAX_VALUE);
-        assertThat(cookie.getVersion(), is(Integer.MAX_VALUE));
+        assertThat(cookie.getVersion(), is(0));
         assertThat(cookie.getAttributes().size(), is(0));
     }
 
@@ -239,7 +238,6 @@ public class CookieTest {
         cookie.setMaxAge(10);
         cookie.setPath("/path");
         cookie.setSecure(false);
-        cookie.setVersion(2);
         cookie.setAttribute("A0", "V0");
 
         Cookie clone = (Cookie) cookie.clone();
@@ -253,7 +251,6 @@ public class CookieTest {
         assertThat(clone.getPath(), is("/path"));
         assertThat(clone.getSecure(), is(false));
         assertThat(clone.isHttpOnly(), is(true));
-        assertThat(clone.getVersion(), is(2));
         assertThat(clone.getAttributes().size(), is(cookie.getAttributes().size()));
 
         assertEquals(cookie, clone);

--- a/spec/src/main/asciidoc/servlet-spec-body.adoc
+++ b/spec/src/main/asciidoc/servlet-spec-body.adoc
@@ -80,7 +80,7 @@ referenced throughout this specification:
 
 * Jakarta EE Platform, version 9
 
-* Jakarta Server Pages™ (JSP), version 3.0
+* Jakarta Server Pages™ (JSP), version 3.1
 
 * Java Naming and Directory Interface™ (JNDI).
 
@@ -1695,11 +1695,9 @@ cache.
 The `HttpServletRequest` interface provides
 the `getCookies` method to obtain an array of cookies that are present
 in the request. These cookies are data sent from the client to the
-server on every request that the client makes. Typically, the only
-information that the client sends back as part of a cookie is the cookie
-name and the cookie value. Other cookie attributes that can be set when
-the cookie is sent to the browser, such as comments, are not typically
-returned. The specification also allows for the cookies to be `HttpOnly`
+server on every request that the client makes. The only information that
+the client sends back as part of a cookie is the cookie name and the cookie
+value. The specification also allows for the cookies to be `HttpOnly`
 cookies. `HttpOnly` cookies indicate to the client that they should not
 be exposed to client-side scripting code (it’s not filtered out unless
 the client knows to look for this attribute). The use of `HttpOnly`
@@ -8551,8 +8549,12 @@ The minimum Java version has been increased to Java 11.
 link:https://github.com/eclipse-ee4j/servlet-api/issues/18[Issue 18]::
 Clarify the decoding and normalization of URI paths.
 
+link:https://github.com/eclipse-ee4j/servlet-api/issues/37[Issue 37]::
+Update Cookie class, related classes and the specification to remove references
+to RFC 2109 and to replace them with RFC 6265.
+
 link:https://github.com/eclipse-ee4j/servlet-api/issues/105[Issue 105]::
-Clarify the behaviour of `getRealPath(String)`
+Clarify the behaviour of `getRealPath(String)`.
 
 link:https://github.com/eclipse-ee4j/servlet-api/issues/175[Issue 175]::
 Provide generic attribute support to cookies, including session cookies, to
@@ -8593,7 +8595,7 @@ interfaces and the `HttpUtils` class as well as various deprecated methods.
 link:https://github.com/eclipse-ee4j/servlet-api/issues/201[Issue 201]::
 Add a `module-info.java` to support using the Servlet API in a modular
 environment as per the Java module system and the Jakarta EE 10 
-link:https://github.com/jakartaee/specification-committee/blob/master/names.adoc[recommendations] 
+link:https://github.com/jakartaee/specification-committee/blob/master/names.adoc[recommendations].
 
 Add a new method `getErrorOnELNotFound()` to `JspPropertyGroupDescriptor` to
 align with changes in the Jakarta Pages 3.1 specification.


### PR DESCRIPTION
In summary:
- setVersion() is NO-OP, getVersion() is hard-coded to 0
- Restrictions on cookie name relaxed to 'must be non-null, non-empty token'

The reason I am proposing this for 6.0 as that I started to look at the TCK and noted that Tomcat's "pass the TCK" mode included various settings for use RFC 2109 rather than RFC 6265. I also recall a TCK challenge caused by the Javadoc continuing to refer to RFC 2109. It struck me that we really should try and get this into 6.0.

The changes turned out to be fairly minimal. Effectively disabling version should have minimal effect as RFC 2965 was never really implemented by any browser.

Reducing the restrictions on cookie names should safe as well.